### PR TITLE
FIx: ヒープサイズが少ない端末でクラッシュする問題の修正

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         android:logo="@drawable/tv_banner"
         android:label="@string/app_name"
         android:usesCleartextTraffic="true"
+        android:largeHeap="true"
         android:theme="@style/Theme_Komorebi_Starting">
 
         <provider

--- a/app/src/main/java/com/beeregg2001/komorebi/data/sync/EpgSyncEngine.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/sync/EpgSyncEngine.kt
@@ -67,18 +67,20 @@ class EpgSyncEngine @Inject constructor(
                                     channelType = type
                                 )
 
-                                // Mapperを使ってAPIモデルからRoomエンティティへ変換
-                                val channels = response.channels.map { EpgDataMapper.toChannelEntity(it.channel) }
-                                val programs = response.channels.flatMap { wrapper ->
-                                    wrapper.programs.map { EpgDataMapper.toProgramEntity(it) }
+                                // ★メモリ最適化: flatMapで全番組を一度にメモリ展開せず、
+                                // チャンネルごとに変換・挿入してピーク使用量を抑える
+                                var totalPrograms = 0
+                                for (wrapper in response.channels) {
+                                    val channel = EpgDataMapper.toChannelEntity(wrapper.channel)
+                                    val programs = wrapper.programs.map { EpgDataMapper.toProgramEntity(it) }
+                                    db.withTransaction {
+                                        db.epgDao().insertEpgData(listOf(channel), programs)
+                                    }
+                                    totalPrograms += programs.size
+                                    // programsはここでスコープ外になりGC対象になる
                                 }
 
-                                // DBに一括挿入（重複は自動で上書き更新される）
-                                db.withTransaction {
-                                    db.epgDao().insertEpgData(channels, programs)
-                                }
-
-                                Log.i(TAG, "Successfully synced EPG for $type (Chunk $chunkIndex: ${programs.size} programs)")
+                                Log.i(TAG, "Successfully synced EPG for $type (Chunk $chunkIndex: $totalPrograms programs)")
                             } catch (e: Exception) {
                                 if (e is CancellationException) throw e
                                 Log.e(TAG, "Error syncing EPG for $type (Chunk $chunkIndex)", e)

--- a/app/src/main/java/com/beeregg2001/komorebi/data/sync/RecordSyncEngine.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/sync/RecordSyncEngine.kt
@@ -1,5 +1,7 @@
 package com.beeregg2001.komorebi.data.sync
 
+import android.app.ActivityManager
+import android.content.Context
 import android.util.Log
 import androidx.room.withTransaction
 import com.beeregg2001.komorebi.data.SettingsRepository
@@ -12,6 +14,7 @@ import com.beeregg2001.komorebi.data.local.entity.SyncMetaEntity
 import com.beeregg2001.komorebi.data.mapper.RecordDataMapper
 import com.beeregg2001.komorebi.util.TitleNormalizer
 import com.beeregg2001.komorebi.util.WikipediaNormalizer
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -55,7 +58,8 @@ class RecordSyncEngine @Inject constructor(
     private val apiService: KonomiApi,
     private val db: AppDatabase,
     private val settingsRepository: SettingsRepository,
-    private val aiSeriesDictionaryDao: AiSeriesDictionaryDao
+    private val aiSeriesDictionaryDao: AiSeriesDictionaryDao,
+    @ApplicationContext private val context: Context
 ) {
     private val _syncProgress = MutableStateFlow(SyncProgress())
     val syncProgress: StateFlow<SyncProgress> = _syncProgress.asStateFlow()
@@ -68,7 +72,17 @@ class RecordSyncEngine @Inject constructor(
     private val smartSyncMutex = Mutex()
     private var activeSyncJob: Job? = null
 
-    private val BATCH_SIZE = 100
+    // ★低メモリ端末（Fire TV Stick等）の判定
+    private val isLowRamDevice: Boolean by lazy {
+        val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        am.isLowRamDevice
+    }
+
+    // ★低メモリ端末ではバッチサイズを小さく、通常端末では大きくする
+    private val BATCH_SIZE get() = if (isLowRamDevice) 30 else 100
+
+    // ★低メモリ端末ではGC後の待機時間を長くする
+    private val GC_DELAY_MS get() = if (isLowRamDevice) 2000L else 1200L
 
     fun clearError() {
         _syncProgress.value = _syncProgress.value.copy(error = null)
@@ -151,8 +165,16 @@ class RecordSyncEngine @Inject constructor(
                     val needsOrphanDeletion = !isResumed && (isInitial || forceFullSync)
                     val allFetchedIds = if (needsOrphanDeletion) mutableSetOf<Int>() else null
 
-                    val dictionary = aiSeriesDictionaryDao.getAllDictionary()
-                        .associate { it.originalTitle to it.normalizedSeriesName }
+                    // ★低メモリ端末対応: isLowRamDeviceの場合は辞書をメモリに全展開せず空Mapを渡す。
+                    // series_nameの解決は後続の startDictionaryResolutionLoop() で行われるため
+                    // 初回ビルドの品質への影響はなく、OOM発生を回避できる。
+                    val dictionary: Map<String, String> = if (isLowRamDevice && isInitial) {
+                        Log.i(TAG, "Low RAM device: skipping dictionary preload to save memory.")
+                        emptyMap()
+                    } else {
+                        aiSeriesDictionaryDao.getAllDictionary()
+                            .associate { it.originalTitle to it.normalizedSeriesName }
+                    }
 
                     val entityBuffer = mutableListOf<RecordedProgramEntity>()
 
@@ -237,9 +259,9 @@ class RecordSyncEngine @Inject constructor(
                             // これにより数千件のデータでもメモリがパンクせずに完走します。
                             if (isInitial) {
                                 System.gc()
-                                delay(1200)
+                                delay(GC_DELAY_MS)
                             } else {
-                                delay(300)
+                                delay(if (isLowRamDevice) 500L else 300L)
                             }
                         }
                     }


### PR DESCRIPTION
FireTVでDB構築時にクラッシュする問題について修正しました。
所有しているFireTV端末(FireTV Cube 2世代)で事象が改善していることを確認しています。

よろしくお願いします。

---
変更サマリー
1. AndroidManifest.xml — largeHeap 追加（最重要）

android:largeHeap="true"
FireTV Stickのデフォルトヒープは約48〜192MBと非常に小さく、これを設定するだけでOOM（Out of Memory）を大幅に回避できます。

2. EpgSyncEngine.kt — ピークメモリ削減
Before（問題のあったコード）:


// 全チャンネルの全番組を一度にflatMapでメモリ展開していた
val programs = response.channels.flatMap { wrapper ->
    wrapper.programs.map { EpgDataMapper.toProgramEntity(it) }
}
db.withTransaction { db.epgDao().insertEpgData(channels, programs) }
After（修正後）:


// チャンネル1つずつ変換・挿入 → ピーク使用量を1/N以下に
for (wrapper in response.channels) {
    val channel = EpgDataMapper.toChannelEntity(wrapper.channel)
    val programs = wrapper.programs.map { EpgDataMapper.toProgramEntity(it) }
    db.withTransaction { db.epgDao().insertEpgData(listOf(channel), programs) }
    // ループを抜けるとprogramsはGC対象になる
}

3. RecordSyncEngine.kt — 低RAM端末の自動検出と適応制御
設定	通常端末	低RAM端末（FireTV Stick等）
BATCH_SIZE	100件	30件
GC後の待機	1200ms	2000ms
ページ間隔	300ms	500ms
辞書プリロード	あり	なし（初回ビルド時のみスキップ）
ActivityManager.isLowRamDevice() でFireTV Stick等を自動判定し、パラメータを動的に切り替えます。辞書の事前ロードスキップは初回ビルド時のみで、辞書解決は後続の startDictionaryResolutionLoop() で行われるため品質に影響しません。