### PR TITLE
Update SmbVlcPlayerScreen.kt

### DIFF
--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/smb/player/SmbVlcPlayerScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/smb/player/SmbVlcPlayerScreen.kt
@@ -40,6 +40,7 @@ import com.beeregg2001.komorebi.common.safeRequestFocus
 import com.beeregg2001.komorebi.data.model.ArchivedComment
 import com.beeregg2001.komorebi.data.model.RecordedProgram
 import com.beeregg2001.komorebi.data.model.StreamQuality
+import com.beeregg2001.komorebi.data.model.AudioMode
 import com.beeregg2001.komorebi.ui.video.player.*
 import com.beeregg2001.komorebi.ui.video.smb.SmbItem
 import com.beeregg2001.komorebi.viewmodel.SettingsViewModel
@@ -715,6 +716,7 @@ fun SmbVlcPlayerScreen(
                                     (tracks.indexOfFirst { it.id == mediaPlayer.audioTrack } + 1) % tracks.size
                                 mediaPlayer.audioTrack = tracks[nextIdx].id
                                 onShowToast("音声: ${tracks[nextIdx].name}")
+                                vs.currentAudioMode = if (vs.currentAudioMode == AudioMode.MAIN) AudioMode.SUB else AudioMode.MAIN
                             } else onShowToast("音声トラックが1つしかありません")
                         },
                         onSpeedToggle = {


### PR DESCRIPTION
Fixed the issue reported in [#92 ](https://github.com/BeerEgg2001/Komorebi/issues/92)    when playing video via ファイルライブラリ(SMB)、音声切替 in プレイヤー設定 now togggle between 主音声 (MAIN) and 副音声 (SUB).