### PR TITLE
Fix: Modern UI の録画再生画面でサブメニューのフォーカスが消失する問題を修正

### DIFF
--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/player/VideoPlayerSubMenu.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/player/VideoPlayerSubMenu.kt
@@ -36,10 +36,46 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.*
+import com.beeregg2001.komorebi.common.safeRequestFocusWithRetry
 import com.beeregg2001.komorebi.data.model.AudioMode
 import kotlinx.coroutines.delay
 import com.beeregg2001.komorebi.data.model.StreamQuality
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
+
+/** サブメニュー内の遷移先と、遷移前後のフォーカス位置を保持する。 */
+@Stable
+internal class SubMenuNavigationState<T : Any> {
+    var destination by mutableStateOf<T?>(null)
+        private set
+
+    private var returnFocusRequester: FocusRequester? = null
+    private var destinationFocusRequester: FocusRequester? = null
+
+    fun navigateTo(
+        destination: T,
+        returnFocusRequester: FocusRequester,
+        destinationFocusRequester: FocusRequester
+    ) {
+        this.returnFocusRequester = returnFocusRequester
+        this.destinationFocusRequester = destinationFocusRequester
+        this.destination = destination
+    }
+
+    fun navigateBack() {
+        destination = null
+        destinationFocusRequester = null
+    }
+
+    fun currentDestinationFocusRequester(): FocusRequester? = destinationFocusRequester
+
+    fun consumeReturnFocusRequester(): FocusRequester? {
+        return returnFocusRequester.also { returnFocusRequester = null }
+    }
+}
+
+@Composable
+internal fun <T : Any> rememberSubMenuNavigationState(): SubMenuNavigationState<T> =
+    remember { SubMenuNavigationState() }
 
 @Composable
 fun VideoTopSubMenuUI(
@@ -352,8 +388,10 @@ fun AnimatedVisibilityScope.ModernVideoSettingsOverlay(
     onClose: () -> Unit
 ) {
     val colors = KomorebiTheme.colors
-    var selectedCategory by remember { mutableStateOf<SubMenuCategory?>(null) }
+    val navigationState = rememberSubMenuNavigationState<SubMenuCategory>()
+    val selectedCategory = navigationState.destination
     val initialFocusRequester = remember { FocusRequester() }
+    val qualityButtonRequester = remember { FocusRequester() }
     val qualityListRequester = remember { FocusRequester() }
 
     LaunchedEffect(Unit) {
@@ -365,12 +403,12 @@ fun AnimatedVisibilityScope.ModernVideoSettingsOverlay(
     }
 
     LaunchedEffect(selectedCategory) {
-        if (selectedCategory == SubMenuCategory.QUALITY) {
-            delay(100)
-            try {
-                qualityListRequester.requestFocus()
-            } catch (e: Exception) {
-            }
+        if (selectedCategory != null) {
+            navigationState.currentDestinationFocusRequester()
+                ?.safeRequestFocusWithRetry("ModernVideoSettings_Destination")
+        } else {
+            navigationState.consumeReturnFocusRequester()
+                ?.safeRequestFocusWithRetry("ModernVideoSettings_Return")
         }
     }
 
@@ -384,11 +422,7 @@ fun AnimatedVisibilityScope.ModernVideoSettingsOverlay(
                             it.nativeKeyEvent.keyCode == android.view.KeyEvent.KEYCODE_ESCAPE)
                 ) {
                     if (selectedCategory != null) {
-                        selectedCategory = null
-                        try {
-                            initialFocusRequester.requestFocus()
-                        } catch (e: Exception) {
-                        }
+                        navigationState.navigateBack()
                         true
                     } else {
                         onClose()
@@ -455,8 +489,15 @@ fun AnimatedVisibilityScope.ModernVideoSettingsOverlay(
                             value = currentQuality.label,
                             icon = Icons.Default.HighQuality,
                             onClick = {
-                                if (isQualitySupported) selectedCategory = SubMenuCategory.QUALITY
+                                if (isQualitySupported) {
+                                    navigationState.navigateTo(
+                                        destination = SubMenuCategory.QUALITY,
+                                        returnFocusRequester = qualityButtonRequester,
+                                        destinationFocusRequester = qualityListRequester
+                                    )
+                                }
                             }, // ★ 無効時は開かない
+                            modifier = Modifier.focusRequester(qualityButtonRequester),
                             enabled = isQualitySupported && availableQualities.isNotEmpty() // ★ 適用
                         )
                         ModernSettingRow(
@@ -496,11 +537,7 @@ fun AnimatedVisibilityScope.ModernVideoSettingsOverlay(
                                 icon = if (isSelected) Icons.Default.CheckCircle else Icons.Default.Settings,
                                 onClick = {
                                     onQualitySelect(quality)
-                                    selectedCategory = null
-                                    try {
-                                        initialFocusRequester.requestFocus()
-                                    } catch (e: Exception) {
-                                    }
+                                    navigationState.navigateBack()
                                 },
                                 highlight = isSelected,
                                 modifier = if (isSelected) Modifier.focusRequester(


### PR DESCRIPTION
## 概要

Modern UIの録画再生サブメニューで、画質の選択画面に入り何も選択せずに戻ると、フォーカスが失われる問題を修正しました。

## 原因

選択画面から戻る際、遷移元の設定項目が再配置される前にフォーカスを要求していたため、復帰先へフォーカスできない場合がありました。

## 修正内容

サブメニューで選択画面を開く前のフォーカス位置を保持し、設定一覧の再配置後にフォーカスを要求するよう変更しました。

## 補足

- Modern UI のみ変更
- Classic UI ではこの問題は発生していません