### PR TITLE
fix: KonomiTV original画質対応+関連regression修正(字幕/再生開始/フォーカス/パフォーマンス)

### DIFF
--- a/app/src/main/cpp/id3conv.cpp
+++ b/app/src/main/cpp/id3conv.cpp
@@ -295,7 +295,15 @@ void CID3Converter::CheckPrivateDataPes(const std::vector<uint8_t> &pes)
     m_buf.push_back(1);
     m_buf.push_back(PRIVATE_STREAM_1);
     m_buf.resize(m_buf.size() + 2); // PES length
-    m_buf.push_back(0x80);
+    // ★ 修正: data_alignment_indicator ビット(0x04)を追加して 0x84 にする。
+    // 元の 0x80 のままだと、このビットが立たず(=0)、Media3標準の Id3Reader が
+    // packetStarted() の冒頭 `if ((flags & FLAG_DATA_ALIGNMENT_INDICATOR) == 0) return;`
+    // で毎回即リターンしてサンプル書き込み自体を開始しない。native側ではPES組み立て・
+    // ID3変換まで正常に完了している(CheckPrivateDataPes ACCEPTEDが出続ける)のに、
+    // Kotlin側のonMetadataが一度も呼ばれない不具合の直接の原因だった。
+    // 上流tsreadexはブラウザ側の独自パーサ(mpegts.js)向けでこのビットを気にしない
+    // 設計だったため、この値のまま見過ごされていた。
+    m_buf.push_back(0x84);
     m_buf.push_back(0x80);
     m_buf.push_back(5);
     m_buf.push_back(static_cast<uint8_t>(pts >> 29) | 0x21); // 3 bits

--- a/app/src/main/java/com/beeregg2001/komorebi/common/UrlBuilder.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/common/UrlBuilder.kt
@@ -115,6 +115,17 @@ object UrlBuilder {
     }
 
     /**
+     * 録画番組のoriginal画質 (MPEG-2 直接再生) 用URL。
+     * サーバー側での再エンコードを一切行わず、録画ファイルダウンロードAPIをそのまま
+     * HTTP Rangeリクエスト対応のTS直接再生ソースとして流用する(KonomiTV本家のmpeg2toh264と同じ発想)。
+     * URL: /api/videos/{id}/download
+     */
+    fun getKonomiTvVideoDownloadUrl(ip: String, port: String, videoId: Int): String {
+        val baseUrl = formatBaseUrl(ip, port, "https")
+        return "$baseUrl/api/videos/$videoId/download"
+    }
+
+    /**
      * シークバー用タイル画像取得 (KonomiTV API)
      * URL: /api/videos/{id}/thumbnail/tiled
      * パラメータなしで巨大なシート画像を取得する仕様

--- a/app/src/main/java/com/beeregg2001/komorebi/data/model/StreamQuality.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/model/StreamQuality.kt
@@ -11,6 +11,9 @@ data class StreamQuality(
     companion object {
         // KonomiTVなどのバックエンド用のデフォルト（固定）リスト
         val DEFAULT_QUALITIES = listOf(
+            // ★ 追加: サーバー側で再エンコードせず、放送波のMPEG-2映像+MPEG-TSをtsreadex経由でそのまま
+            // 配信する画質。クライアント側でtsreadex相当の処理(NativeLib)を通す必要があるためisRawTs=true
+            StreamQuality("オリジナル (MPEG-2)", "original", isRawTs = true),
             StreamQuality("1080p (60fps)", "1080p-60fps"),
             StreamQuality("1080p", "1080p"),
             StreamQuality("810p", "810p"),

--- a/app/src/main/java/com/beeregg2001/komorebi/data/repository/KonomiRepository.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/repository/KonomiRepository.kt
@@ -332,6 +332,12 @@ class KonomiRepository @Inject constructor(
     ): String {
         val ip = settingsRepository.konomiIp.first()
         val port = settingsRepository.konomiPort.first()
+        // ★ 追加: original画質はHLS(VideoEncodingTask)を経由せず、録画ファイルダウンロードAPIを
+        // 生MPEG-TS直接再生ソースとしてそのまま使う(KonomiTVサーバー側もoriginal指定時はHLS系
+        // APIを422で拒否する実装になっている)。session_id/offsetSecはHLS専用のため使用しない。
+        if (quality == "original") {
+            return UrlBuilder.getKonomiTvVideoDownloadUrl(ip, port, videoId)
+        }
         return UrlBuilder.getVideoPlaylistUrl(ip, port, videoId, sessionId, quality)
     }
 

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onKeyEvent
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.*
@@ -115,7 +116,11 @@ fun HomeLauncherScreen(
     hasActivePlayer: Boolean = false,
     onReturnToPlayerClick: () -> Unit = {},
     aiFocusReturnTick: Int = 0,
-    onAiReturnConsumed: () -> Unit = {}
+    onAiReturnConsumed: () -> Unit = {},
+    // フルスクリーンのプレイヤーが手前に出ている間は true。
+    // ホーム画面はプレイヤー表示中も(スクロール位置とフォーカスを保つため)
+    // Compose ツリーに残り続けるので、見えていない間の定期通信を明示的に止める。
+    isPlayerActiveFullScreen: Boolean = false
 ) {
     val ui = rememberHomeLauncherState(
         initialTabIndex,
@@ -149,6 +154,10 @@ fun HomeLauncherScreen(
         isSettingsOpen, isRecordListOpen, isReserveOverlayOpen
     ) && !hasActivePlayer
 
+    // ★ 追加: PR #103でプレイヤー表示中もこのホーム画面自体が破棄されず常駐するようになった影響で、
+    // プレイヤーを開く直前にフォーカスしていた項目の論理フォーカスが残留し、プレイヤーから戻った際の
+    // 復元用requestFocus()を阻害することがある。明示的にクリアしてから要求し直す。
+    val focusManager = LocalFocusManager.current
     val returnPlayerFocusRequester = remember { FocusRequester() }
     val displayFlatChannels = remember(groupedChannels) { groupedChannels.values.flatten() }
 
@@ -179,9 +188,17 @@ fun HomeLauncherScreen(
 
     var lastHomeRefreshTime by remember { mutableLongStateOf(0L) }
 
-    LaunchedEffect(activeRenderIndex) {
+    LaunchedEffect(activeRenderIndex, isPlayerActiveFullScreen) {
         val currentLabel = tabs.getOrNull(activeRenderIndex) ?: "ホーム"
         ui.isCurrentTabContentReady = false
+
+        // プレイヤーが前面に出ている間、ホーム画面は見えていない。
+        // ここで定期取得を走らせると、再生と帯域・CPU を奪い合って
+        // 再生も UI 操作ももたつく原因になる。
+        if (isPlayerActiveFullScreen) {
+            channelViewModel.stopPolling()
+            return@LaunchedEffect
+        }
 
         if (currentLabel == "ホーム") {
             channelViewModel.startPolling()
@@ -251,6 +268,7 @@ fun HomeLauncherScreen(
 
     LaunchedEffect(isReturningFromPlayer) {
         if (isReturningFromPlayer && !isFullScreenMode) {
+            focusManager.clearFocus(force = true)
             ui.safeHouseRequester.safeRequestFocusWithRetry("SafeHouse_Return")
             delay(150)
 
@@ -786,7 +804,10 @@ fun HomeLauncherScreen(
                             },
                             onHistoryClick = { historyItem ->
                                 val programId = historyItem.program.id.toIntOrNull()
-                                val betterProgram = ui.recentRecordings.find { it.id == programId }
+                                // クリック時にのみ必要な値なので、composition では購読せず
+                                // ここで ViewModel の最新値を直接読み出す。
+                                val betterProgram =
+                                    recordViewModel.recentRecordings.value.find { it.id == programId }
                                 onProgramSelected(
                                     betterProgram?.copy(playbackPosition = historyItem.playback_position)
                                         ?: KonomiDataMapper.toDomainModel(historyItem)

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherState.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherState.kt
@@ -88,9 +88,6 @@ class HomeLauncherState(
     // --- データ保持 ---
     var watchHistory by mutableStateOf<List<KonomiHistoryProgram>>(emptyList())
     var lastChannels by mutableStateOf<List<Channel>>(emptyList())
-    var recentRecordings by mutableStateOf<List<RecordedProgram>>(emptyList())
-    var isLoadingInitial by mutableStateOf(false)
-    var isLoadingMore by mutableStateOf(false)
     var reserves by mutableStateOf<List<ReserveItem>>(emptyList())
 
     var hotChannels by mutableStateOf<List<UiChannelState>>(emptyList())
@@ -105,11 +102,6 @@ class HomeLauncherState(
     var openedSeriesTitle by mutableStateOf<String?>(null)
     var isSeriesListOpen by mutableStateOf(false)
 
-    var favoriteBaseballTeams by mutableStateOf<Set<String>>(emptySet())
-    var favoriteBaseballGames by mutableStateOf<List<Pair<String, List<BaseballGameInfo>>>>(
-        emptyList()
-    )
-
     // ★ 修正: タブがいくつ増えても対応できるようにRequesterをあらかじめ余裕を持って生成しておく
     val tabFocusRequesters = List(10) { FocusRequester() }
     val contentFirstItemRequesters = List(10) { FocusRequester() }
@@ -122,6 +114,14 @@ class HomeLauncherState(
             KonomiDataMapper.toDomainModel(it)
         }
 
+    // 直近に onTabSelected を処理したタブ番号。
+    // 十字キーでのタブ移動は Row の onPreviewKeyEvent → moveTabByDpad で1回、
+    // その後の遅延フォーカス要求で発火する Tab の onFocus でもう1回、と
+    // 同じタブに対して onTabSelected が二重に呼ばれる。ここで起動される
+    // refreshHomeData() / fetchReserves() / 録画同期はいずれも重い処理のため、
+    // 二重起動するとタブ移動のたびに無駄な通信と CPU 負荷が倍増していた。
+    private var lastDispatchedTabIndex: Int = -1
+
     @RequiresApi(Build.VERSION_CODES.O)
     fun onTabSelected(
         index: Int,
@@ -133,6 +133,11 @@ class HomeLauncherState(
         reserveViewModel: ReserveViewModel
     ) {
         onTabChange(index)
+
+        // 同じタブへの重複した選択通知では、重いデータ取得を再実行しない。
+        if (lastDispatchedTabIndex == index) return
+        lastDispatchedTabIndex = index
+
         isCurrentTabContentReady = false
         homeViewModel.clearFocusMemory()
 
@@ -244,11 +249,19 @@ fun rememberHomeLauncherState(
         state.selectedTabIndex = initialTabIndex
     }
 
+    // ここでの collectAsState は HomeLauncherScreen 自身のリコンポーズ範囲に紐づくため、
+    // 購読した Flow が1つ更新されるだけで巨大な HomeLauncherScreen 全体が作り直される。
+    // 実際に画面へ描画されている値だけを購読し、無駄な購読は行わない。
+    //
+    // 特に recentRecordings は Room の Flow で、初回起動時の録画同期中は
+    // ページ書き込みのたびに何度も発火する。これを購読していたため、
+    // 「初回起動時にバックグラウンド処理が走っている間だけ操作が極端に重い」
+    // 状態になっていた。クリック時にしか使わない値なので購読をやめ、
+    // 必要になった時点で ViewModel から直接読み出す。
+    // isLoadingInitial / isLoadingMore / favoriteBaseballTeams / favoriteBaseballGames は
+    // ここで代入していたものの参照箇所が一切なく、リコンポーズを誘発するだけだった。
     state.watchHistory = homeViewModel.watchHistory.collectAsState().value
     state.lastChannels = homeViewModel.lastWatchedChannelFlow.collectAsState().value
-    state.recentRecordings = recordViewModel.recentRecordings.collectAsState().value
-    state.isLoadingInitial = recordViewModel.isRecordingLoading.collectAsState().value
-    state.isLoadingMore = recordViewModel.isLoadingMore.collectAsState().value
     state.reserves = reserveViewModel.reserves.collectAsState().value
 
     val liveRows by channelViewModel.liveRows.collectAsState()
@@ -264,9 +277,6 @@ fun rememberHomeLauncherState(
         val eData = state.epgUiState
         if (eData is EpgUiState.Success) eData.logoUrls else emptyList()
     }
-
-    state.favoriteBaseballTeams = homeViewModel.favoriteBaseballTeams.collectAsState().value
-    state.favoriteBaseballGames = homeViewModel.favoriteBaseballGames.collectAsState().value
 
     return state
 }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/LiveContents.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/LiveContents.kt
@@ -50,7 +50,6 @@ import com.beeregg2001.komorebi.common.safeRequestFocus
 import com.beeregg2001.komorebi.common.safeRequestFocusWithRetry
 import com.beeregg2001.komorebi.data.model.Channel
 import com.beeregg2001.komorebi.data.model.UiChannelState
-import com.beeregg2001.komorebi.ui.live.LivePlayerScreen
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
 import com.beeregg2001.komorebi.viewmodel.*
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -90,12 +89,6 @@ fun LiveContent(
     val targetChannelFocusRequester = remember { FocusRequester() }
     val isPlayerActive = selectedChannel != null
     val colors = KomorebiTheme.colors
-
-    var isMiniListOpen by remember { mutableStateOf(false) }
-    var showOverlay by remember { mutableStateOf(true) }
-    var isManualOverlay by remember { mutableStateOf(false) }
-    var isPinnedOverlay by remember { mutableStateOf(false) }
-    var isSubMenuOpen by remember { mutableStateOf(false) }
 
     var pendingChannel by remember { mutableStateOf<UiChannelState?>(null) }
     var focusedChannel by remember { mutableStateOf<UiChannelState?>(null) }
@@ -213,15 +206,12 @@ fun LiveContent(
                 CircularProgressIndicator(color = colors.textPrimary.copy(alpha = 0.5f))
             }
         } else {
+            // ★ 修正: フルスクリーン再生中に上下左右をCancelする指定を削除した。
+            // 背面ツリーへのフォーカス侵入はMainRootBackground側で遮断済みであり、
+            // 万一フォーカスがここへ残ってしまった場合、この指定があると
+            // 十字キーが完全に無反応(脱出不能)になり操作不能に見えてしまうため。
             Column(
-                modifier = modifier
-                    .fillMaxSize()
-                    .then(if (isPlayerActive && !isPiPMode) Modifier.focusProperties {
-                        up = FocusRequester.Cancel
-                        down = FocusRequester.Cancel
-                        left = FocusRequester.Cancel
-                        right = FocusRequester.Cancel
-                    } else Modifier)
+                modifier = modifier.fillMaxSize()
             ) {
                 Box(
                     modifier = Modifier
@@ -313,25 +303,17 @@ fun LiveContent(
             }
         }
 
-        if (selectedChannel != null && !isPiPMode) {
-            LivePlayerScreen(
-                channel = selectedChannel,
-                onChannelSelect = { onChannelClick(it) },
-                onBackPressed = { onChannelClick(null) },
-                isMiniListOpen = isMiniListOpen,
-                onMiniListToggle = { isMiniListOpen = it },
-                showOverlay = showOverlay,
-                onShowOverlayChange = { showOverlay = it },
-                isManualOverlay = isManualOverlay,
-                onManualOverlayChange = { isManualOverlay = it },
-                isPinnedOverlay = isPinnedOverlay,
-                onPinnedOverlayChange = { isPinnedOverlay = it },
-                isSubMenuOpen = isSubMenuOpen,
-                onSubMenuToggle = { isSubMenuOpen = it },
-                reserveViewModel = reserveViewModel,
-                onShowToast = { }
-            )
-        }
+        // ★ 削除: ここに2つ目のLivePlayerScreenを生成していたが、ライブ再生は
+        // MainRootScreenの前面レイヤー(zIndex=1)が唯一の担当であり、完全な重複だった。
+        //
+        // 以前は「プレイヤー表示中はホーム画面自体をComposeツリーから破棄する」実装だったため
+        // この分岐は事実上到達不能な死にコードだったが、スクロール位置とフォーカスを保持するため
+        // ホーム画面を破棄しない実装へ変更したことで生成されるようになり、
+        // ・前面プレイヤーと同じLivePlayerViewModel(Activityスコープ)を二重に操作する
+        // ・背面に隠れた2つ目のプレイヤーUIがフォーカスを奪い合う
+        //   (十字キーは見えない背面リストの中で動くため無反応に見え、
+        //    決定キーはそのリストのonChannelSelect→onChannelClickでメイン画面の選局が起きる)
+        // という不具合を起こしていた。
     }
 }
 

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/ChannelListOverlay.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/ChannelListOverlay.kt
@@ -71,8 +71,27 @@ fun ChannelListOverlay(
 
     val selectedTabIndex = availableTabKeys.indexOf(selectedTab).coerceAtLeast(0)
 
-    LaunchedEffect(selectedTab) {
-        val index = currentChannels.indexOfFirst { it.id == currentChannelId }
+    // ★ 修正: フォーカス要求先(呼び出し側のfocusRequester)を必ずレイアウト上に存在させる。
+    // 以前は「currentChannelIdと一致する項目」だけに結び付けていたため、
+    // 一致する項目が現在のタブに無い(2画面目が未選局・別タブ・一覧が未取得など)場合は
+    // どのノードにも接続されず、requestFocus()が失敗してフォーカスが迷子になっていた。
+    val focusTargetChannelId = remember(currentChannels, currentChannelId) {
+        if (currentChannels.any { it.id == currentChannelId }) currentChannelId
+        else currentChannels.firstOrNull()?.id
+    }
+
+    // チャンネル一覧の取得が遅れてタブが決まらなかった場合に、有効なタブへ復帰させる
+    LaunchedEffect(availableTabKeys) {
+        if (availableTabKeys.isNotEmpty() && selectedTab !in availableTabKeys) {
+            selectedTab = initialTab
+        }
+    }
+
+    // 一覧の取得完了でフォーカス先が確定した場合にも、その項目まで確実にスクロールする
+    // (LazyRowは可視範囲外の項目を生成しないため、スクロールしないとFocusRequesterが接続されない)。
+    // キーはIDのみとし、定期更新でリストが作り直されてもスクロール位置を奪わないようにする。
+    LaunchedEffect(selectedTab, focusTargetChannelId) {
+        val index = currentChannels.indexOfFirst { it.id == focusTargetChannelId }
         if (index >= 0) {
             listState.scrollToItem(index)
         } else {
@@ -170,7 +189,8 @@ fun ChannelListOverlay(
             items(currentChannels, key = { it.id }) { channel ->
                 val isSelected = channel.id == currentChannelId
                 val itemRequester =
-                    if (isSelected) focusRequester else remember { FocusRequester() }
+                    if (channel.id == focusTargetChannelId) focusRequester
+                    else remember { FocusRequester() }
 
                 ChannelCardItem(
                     channel = channel,

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/LiveDualPlayer.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/LiveDualPlayer.kt
@@ -6,6 +6,8 @@
 package com.beeregg2001.komorebi.ui.live
 
 import android.os.Build
+import android.view.SurfaceView
+import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
@@ -36,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
-import androidx.media3.ui.PlayerView
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
@@ -47,6 +48,19 @@ import com.beeregg2001.komorebi.ui.subtitle.NativeCaptionCue
 import com.beeregg2001.komorebi.ui.subtitle.NativeCaptionOverlay
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
 import kotlinx.coroutines.delay
+
+/**
+ * 映像の表示アスペクト比（横 / 縦）を求める。
+ *
+ * ExoPlayer が通知するピクセルアスペクト比（1440x1080 のアナモルフィック等）を加味する。
+ * 映像サイズがまだ取得できていない場合は 16:9 とみなす。
+ */
+private fun calcVideoAspectRatio(width: Int, height: Int, pixelRatio: Float): Float {
+    if (width <= 0 || height <= 0) return 16f / 9f
+    val par = if (pixelRatio > 0f) pixelRatio else 1f
+    val ratio = (width.toFloat() * par) / height.toFloat()
+    return if (ratio.isFinite() && ratio > 0f) ratio else 16f / 9f
+}
 
 // ==============================================
 // 本物のプレイヤーを配置した DualDisplayPlayer コンポーネント
@@ -70,7 +84,12 @@ fun DualDisplayPlayer(
     dualVideoHeight: Int,
     dualPixelRatio: Float,
     dualCaptionCue: NativeCaptionCue?,
-    isSubtitleEnabled: Boolean
+    isSubtitleEnabled: Boolean,
+    // ★ 追加: 二画面表示中のフォーカス受け皿。単画面時のPlayerView(AndroidView)と同じ役割で、
+    // 呼び出し側からFocusRequesterを結び付けられるようにする。
+    modifier: Modifier = Modifier,
+    // ★ 追加: ミニリスト/サブメニュー表示中はプレイヤー本体をフォーカス対象から外す(単画面時と同じ挙動)
+    isFocusable: Boolean = true
 ) {
     val colors = KomorebiTheme.colors
     val animatedLeftWeight by animateFloatAsState(
@@ -112,10 +131,14 @@ fun DualDisplayPlayer(
 
     val showInfo = !isIdle || isMiniListOpen
 
+    // 映像の表示アスペクト比。取得できるまでは 16:9 とみなす
+    val mainAspectRatio = calcVideoAspectRatio(mainVideoWidth, mainVideoHeight, mainPixelRatio)
+    val dualAspectRatio = calcVideoAspectRatio(dualVideoWidth, dualVideoHeight, dualPixelRatio)
+
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
-            .focusable()
+            .focusable(isFocusable)
     ) {
         // --- 左画面 (メインプレイヤー) ---
         Box(
@@ -128,25 +151,39 @@ fun DualDisplayPlayer(
         ) {
             if (mainPlayer != null) {
                 AndroidView(
-                    factory = {
-                        PlayerView(it).apply {
-                            player = mainPlayer
-                            useController = false
+                    factory = { ctx ->
+                        AspectRatioFrameLayout(ctx).apply {
+                            // ビュー自体のサイズを Compose 側 (aspectRatio) で映像の矩形そのものに
+                            // 合わせるため、ビュー内部でのレターボックス計算は行わない (FILL)
+                            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
                             keepScreenOn = true
-                            resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                            addView(
+                                SurfaceView(ctx).apply {
+                                    layoutParams = ViewGroup.LayoutParams(
+                                        ViewGroup.LayoutParams.MATCH_PARENT,
+                                        ViewGroup.LayoutParams.MATCH_PARENT
+                                    )
+                                }
+                            )
                         }
                     },
                     update = { view ->
-                        if (view.player != mainPlayer) {
-                            view.player = mainPlayer
-                        }
-                        view.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                        // 全画面表示から二画面表示へ切り替えた直後に、映像の出力先が
+                        // 全画面用の古い Surface に残ったままになると、映像が全画面サイズの
+                        // まま描画され一部だけを切り出したズーム表示になる。
+                        // 毎回この二画面用の SurfaceView へ明示的に結び付け直して防ぐ。
+                        val surfaceView = view.getChildAt(0) as SurfaceView
+                        mainPlayer.setVideoSurfaceView(surfaceView)
                     },
                     // ★ 修正2: 破棄時に参照を外す
                     onRelease = { view ->
-                        view.player = null
+                        (view.getChildAt(0) as? SurfaceView)?.let {
+                            mainPlayer.clearVideoSurfaceView(it)
+                        }
                     },
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .aspectRatio(mainAspectRatio)
                 )
 
                 var isMainBuffering by remember { mutableStateOf(false) }
@@ -205,10 +242,13 @@ fun DualDisplayPlayer(
             }
 
             if (isSubtitleEnabled) {
+                // 字幕は映像の矩形に重ねる (枠いっぱいに広げるとレターボックス分だけ縦に伸びてしまう)
                 NativeCaptionOverlay(
                     cue = mainCaptionCue,
                     visible = !isUiVisible,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier
+                        .align(Alignment.Center)
+                        .aspectRatio(mainAspectRatio)
                 )
             }
 
@@ -239,25 +279,34 @@ fun DualDisplayPlayer(
             if (state.dualRightChannel != null) {
                 if (dualPlayer != null) {
                     AndroidView(
-                        factory = {
-                            PlayerView(it).apply {
-                                player = dualPlayer
-                                useController = false
+                        factory = { ctx ->
+                            AspectRatioFrameLayout(ctx).apply {
+                                // 左画面と同様、レターボックスは Compose 側で行う
+                                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FILL
                                 keepScreenOn = true
-                                resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                                addView(
+                                    SurfaceView(ctx).apply {
+                                        layoutParams = ViewGroup.LayoutParams(
+                                            ViewGroup.LayoutParams.MATCH_PARENT,
+                                            ViewGroup.LayoutParams.MATCH_PARENT
+                                        )
+                                    }
+                                )
                             }
                         },
                         update = { view ->
-                            if (view.player != dualPlayer) {
-                                view.player = dualPlayer
-                            }
-                            view.resizeMode = AspectRatioFrameLayout.RESIZE_MODE_FIT
+                            val surfaceView = view.getChildAt(0) as SurfaceView
+                            dualPlayer.setVideoSurfaceView(surfaceView)
                         },
                         // ★ 修正2: 破棄時に参照を外す
                         onRelease = { view ->
-                            view.player = null
+                            (view.getChildAt(0) as? SurfaceView)?.let {
+                                dualPlayer.clearVideoSurfaceView(it)
+                            }
                         },
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .aspectRatio(dualAspectRatio)
                     )
 
                     var isDualBuffering by remember { mutableStateOf(false) }
@@ -316,10 +365,13 @@ fun DualDisplayPlayer(
                 }
 
                 if (isSubtitleEnabled) {
+                    // 左画面と同様、字幕は映像の矩形に重ねる
                     NativeCaptionOverlay(
                         cue = dualCaptionCue,
                         visible = !isUiVisible,
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .aspectRatio(dualAspectRatio)
                     )
                 }
 

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/LivePlayerScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/LivePlayerScreen.kt
@@ -5,6 +5,7 @@ package com.beeregg2001.komorebi.ui.live
 import android.os.Build
 import android.util.Log
 import android.view.KeyEvent as NativeKeyEvent
+import androidx.activity.compose.BackHandler
 import androidx.annotation.OptIn
 import androidx.annotation.RequiresApi
 import androidx.compose.animation.*
@@ -22,6 +23,7 @@ import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.key.*
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -38,6 +40,7 @@ import com.beeregg2001.komorebi.common.AppStrings
 import com.beeregg2001.komorebi.data.SettingsRepository
 import com.beeregg2001.komorebi.viewmodel.*
 import com.beeregg2001.komorebi.common.safeRequestFocus
+import com.beeregg2001.komorebi.common.safeRequestFocusWithRetry
 import com.beeregg2001.komorebi.data.model.AudioMode
 import com.beeregg2001.komorebi.data.model.Channel
 import com.beeregg2001.komorebi.data.model.StreamQuality
@@ -85,6 +88,13 @@ fun LivePlayerScreen(
     val uiContext = LocalContext.current
     val colors = KomorebiTheme.colors
     val scope = rememberCoroutineScope()
+    // ★ 追加: PR #103でホーム画面の背面レイヤーが破棄されず常駐するようになった影響で、
+    // プレイヤー表示直前にホーム側のリスト項目等が持っていた論理フォーカスが残留し、
+    // その後のrequestFocus()が正しく機能しない(=方向キー/決定キーが効かない)ケースがある。
+    // これはComposeのフォーカスシステムの既知の癖で、canFocus=falseになった祖先を持つ
+    // ノードが元々フォーカスを保持していると、新規のrequestFocus()呼び出しが失敗しうる。
+    // clearFocus(force = true)で明示的にフォーカス参照をリセットしてから要求し直す。
+    val focusManager = LocalFocusManager.current
 
     val ps = rememberLivePlayerState(uiContext)
 
@@ -120,6 +130,36 @@ fun LivePlayerScreen(
     val audioOutputMode by settingsViewModel.audioOutputMode.collectAsState()
     val liveSubtitleDefaultStr by settingsViewModel.liveSubtitleDefault.collectAsState()
     val allowMirakurunDual by settingsViewModel.labAllowMirakurunDual.collectAsState()
+
+    // ★ 追加: 二画面表示を解除する処理を共通化。従来はサブメニューのトグルボタンからしか
+    // 呼び出せなかったが、下のBackHandlerからも同じ後片付け(ソース/画質の復元含む)を
+    // 行えるようにする。
+    val exitDualDisplayMode: () -> Unit = {
+        ps.isDualDisplayMode = false
+        ps.activeDualPlayerIndex = 0
+        ps.dualRightChannel = null
+        ps.leftScreenWeight = 1f
+        ps.rightScreenWeight = 1f
+        if (ps.previousStreamSource != null) {
+            if (availableSources.contains(ps.previousStreamSource!!)) {
+                ps.currentStreamSource = ps.previousStreamSource!!
+                onShowToast("元のストリーミングソースに復帰しました")
+            }
+            ps.previousStreamSource = null
+        }
+        if (ps.previousQuality != null) {
+            ps.currentQuality = ps.previousQuality!!
+            onShowToast("元の画質に復帰しました")
+            ps.previousQuality = null
+        }
+    }
+
+    // ★ 追加: 二画面表示中は戻るキーの1段階目として単画面表示に戻す。
+    // これまでBackHandlerが存在せず、戻るキーが直接MainRootScreen側のグローバルハンドラーに
+    // 突き抜けてホーム画面まで戻ってしまっていた(二画面表示自体は解除されない)不具合を修正する。
+    BackHandler(enabled = ps.isDualDisplayMode) {
+        exitDualDisplayMode()
+    }
 
     val playerUiMode by settingsViewModel.playerUiMode.collectAsState()
     val isModern = playerUiMode == "MODERN"
@@ -250,6 +290,23 @@ fun LivePlayerScreen(
                     ps.currentStreamSource = StreamSource.KONOMITV
                     onShowToast("負荷軽減のためKonomiTVソースに切り替えました")
                 }
+            } else if (ps.currentStreamSource == StreamSource.KONOMITV &&
+                ps.currentQuality.value == "original" && allowMirakurunDual != "ON"
+            ) {
+                // ★ 追加: KonomiTVのoriginal画質もMIRAKURUN/EDCB同様の重量な生TSパイプラインを
+                // 使うため、ソース切替の代わりに画質を通常画質へダウングレードする
+                // ★ 修正: 単に「originalではない最初の画質」を選ぶと、DEFAULT_QUALITIESの並び順
+                // (original, 1080p-60fps, 1080p, ...)により1080p(60fps)が選ばれてしまい、
+                // 二画面表示の負荷軽減という目的に反していた。LivePlayerSubMenu.ktの
+                // デュアル表示時フォールバックと同じ基準(720p)に揃える。
+                val fallback = availableQualities.firstOrNull {
+                    it.value.contains("720") || it.label.contains("720")
+                } ?: availableQualities.firstOrNull { it.value != "original" }
+                if (fallback != null) {
+                    ps.previousQuality = ps.currentQuality
+                    ps.currentQuality = fallback
+                    onShowToast("負荷軽減のため画質を ${fallback.label} に変更しました")
+                }
             }
         } else {
             if (!ps.isDualDisplayMode && ps.previousStreamSource != null) {
@@ -258,6 +315,11 @@ fun LivePlayerScreen(
                     onShowToast("元のストリーミングソースに復帰しました")
                 }
                 ps.previousStreamSource = null
+            }
+            if (!ps.isDualDisplayMode && ps.previousQuality != null) {
+                ps.currentQuality = ps.previousQuality!!
+                onShowToast("元の画質に復帰しました")
+                ps.previousQuality = null
             }
         }
     }
@@ -288,6 +350,14 @@ fun LivePlayerScreen(
             }
         }
         mainPlayer?.addListener(listener)
+        // リスナー登録時点で既に映像サイズが確定している場合は onVideoSizeChanged が
+        // 呼ばれないため、ここで現在値を取り込んでおく
+        mainPlayer?.videoSize?.let { size ->
+            if (size.width > 0 && size.height > 0) {
+                videoWidth = size.width; videoHeight =
+                    size.height; pixelWidthHeightRatio = size.pixelWidthHeightRatio
+            }
+        }
         isMainBuffering = mainPlayer?.playbackState == Player.STATE_BUFFERING
         onDispose { mainPlayer?.removeListener(listener) }
     }
@@ -304,6 +374,13 @@ fun LivePlayerScreen(
             }
         }
         dualPlayer?.addListener(listener)
+        // メイン側と同様、登録時点の映像サイズを取り込んでおく
+        dualPlayer?.videoSize?.let { size ->
+            if (size.width > 0 && size.height > 0) {
+                dualVideoWidth = size.width; dualVideoHeight =
+                    size.height; dualPixelWidthHeightRatio = size.pixelWidthHeightRatio
+            }
+        }
         isDualBuffering = dualPlayer?.playbackState == Player.STATE_BUFFERING
         onDispose { dualPlayer?.removeListener(listener) }
     }
@@ -479,15 +556,38 @@ fun LivePlayerScreen(
 
     LaunchedEffect(isMiniListOpen) {
         if (isMiniListOpen) {
-            channelViewModel.fetchChannels(); delay(200); listFocusRequester.safeRequestFocus(TAG)
+            channelViewModel.fetchChannels(); delay(200)
+            // ★ 修正: 単発のsafeRequestFocus()だと、ホーム画面がプレイヤー表示中も破棄されず
+            // 常駐するようになった影響で、レイアウト確定前にフォーカス要求が来て失敗すると
+            // そのまま復帰しない(=方向キー/決定キーが効かない)ことがあったため、リトライ版に変更する。
+            // さらに、ホーム画面側の項目が持っていた古い論理フォーカスがcanFocus=false化後も
+            // 内部的に残留し、新規のrequestFocus()を阻害することがあるため、まず明示的にクリアする。
+            focusManager.clearFocus(force = true)
+            listFocusRequester.safeRequestFocusWithRetry(TAG, maxRetries = 10, delayMillis = 50)
         } else if (!currentIsManualOverlay && !currentIsSubMenuOpen && !isPiPMode && ps.lCropMode == LCropMode.HIDDEN) {
-            delay(100); mainFocusRequester.safeRequestFocus(TAG)
+            delay(100)
+            focusManager.clearFocus(force = true)
+            mainFocusRequester.safeRequestFocusWithRetry(TAG, maxRetries = 10, delayMillis = 50)
         }
     }
 
     LaunchedEffect(isSubMenuOpen) {
         if (isSubMenuOpen && !isPiPMode) {
             delay(150); subMenuFocusRequester.safeRequestFocus(TAG)
+        } else if (!isSubMenuOpen && !isMiniListOpen && !isPiPMode && ps.lCropMode == LCropMode.HIDDEN) {
+            // ★ 追加: サブメニューを閉じるとフォーカスを持っていた項目ごと破棄されるため、
+            // 明示的にプレイヤー本体へフォーカスを戻す。
+            // (戻さないとフォーカスが迷子になり、以降の十字キー/決定キーが効かなくなる)
+            delay(100); mainFocusRequester.safeRequestFocus(TAG)
+        }
+    }
+
+    // ★ 追加: 単画面 ⇔ 二画面 の切り替えでプレイヤーのフォーカス受け皿ノードが作り直されるため、
+    // 切り替え後にフォーカスをプレイヤー本体へ引き戻す。
+    LaunchedEffect(ps.isDualDisplayMode) {
+        if (!isPiPMode && !isMiniListOpen && !isSubMenuOpen && ps.lCropMode == LCropMode.HIDDEN) {
+            delay(200)
+            mainFocusRequester.safeRequestFocusWithRetry(TAG, maxRetries = 5, delayMillis = 60)
         }
     }
 
@@ -522,6 +622,13 @@ fun LivePlayerScreen(
     ) {
         if (ps.isDualDisplayMode) {
             DualDisplayPlayer(
+                // ★ 修正: 二画面表示中もプレイヤー本体をフォーカスの受け皿にする。
+                // これが無いとmainFocusRequesterがどのノードにも接続されず、
+                // サブメニュー/ミニリストを閉じた後にフォーカスが迷子になり、
+                // 背面のホーム画面へフォーカスが落ちてしまう。
+                modifier = Modifier.focusRequester(mainFocusRequester),
+                isFocusable = !isPiPMode && !isMiniListOpen && !isSubMenuOpen &&
+                    ps.lCropMode == LCropMode.HIDDEN,
                 state = ps,
                 leftChannel = currentChannelItem,
                 getLogoUrl = { channelId -> channelViewModel.getChannelLogoUrl(channelId) },
@@ -726,9 +833,19 @@ fun LivePlayerScreen(
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
         ) {
+            // ★ 修正: 二画面表示で2画面目(右)を操作中は、右画面のチャンネルを基準にする。
+            // 初期タブ・スクロール位置・フォーカス位置がすべてこのIDで決まるため、
+            // メイン(左)のチャンネルを渡していると2画面目の選局時に意図しない位置が選ばれる。
+            val miniListCurrentChannelId =
+                if (ps.isDualDisplayMode && ps.activeDualPlayerIndex == 1) {
+                    ps.dualRightChannel?.id ?: currentChannelItem.id
+                } else {
+                    currentChannelItem.id
+                }
+
             ChannelListOverlay(
                 groupedChannels = displayGroupedChannels,
-                currentChannelId = currentChannelItem.id,
+                currentChannelId = miniListCurrentChannelId,
                 onChannelSelect = { selectedChannel ->
                     if (!ps.isDualDisplayMode) onChannelSelect(selectedChannel) else {
                         if (ps.activeDualPlayerIndex == 0) onChannelSelect(selectedChannel) else ps.dualRightChannel =
@@ -779,19 +896,26 @@ fun LivePlayerScreen(
                                 ps.currentStreamSource = StreamSource.KONOMITV
                                 onShowToast("負荷軽減のためKonomiTVソースに切り替えました")
                             }
+                        } else if (ps.currentStreamSource == StreamSource.KONOMITV &&
+                            ps.currentQuality.value == "original" && allowMirakurunDual != "ON"
+                        ) {
+                            // ★ 追加: KonomiTVのoriginal画質もMIRAKURUN/EDCB同様の重量な生TSパイプラインを
+                            // 使うため、ソース切替の代わりに画質を通常画質へダウングレードする
+                            // ★ 修正: 単に「originalではない最初の画質」を選ぶと、DEFAULT_QUALITIESの並び順
+                // (original, 1080p-60fps, 1080p, ...)により1080p(60fps)が選ばれてしまい、
+                // 二画面表示の負荷軽減という目的に反していた。LivePlayerSubMenu.ktの
+                // デュアル表示時フォールバックと同じ基準(720p)に揃える。
+                val fallback = availableQualities.firstOrNull {
+                    it.value.contains("720") || it.label.contains("720")
+                } ?: availableQualities.firstOrNull { it.value != "original" }
+                            if (fallback != null) {
+                                ps.previousQuality = ps.currentQuality
+                                ps.currentQuality = fallback
+                                onShowToast("負荷軽減のため画質を ${fallback.label} に変更しました")
+                            }
                         }
                     } else {
-                        ps.activeDualPlayerIndex = 0
-                        ps.dualRightChannel = null
-                        ps.leftScreenWeight = 1f
-                        ps.rightScreenWeight = 1f
-                        if (ps.previousStreamSource != null) {
-                            if (availableSources.contains(ps.previousStreamSource!!)) {
-                                ps.currentStreamSource = ps.previousStreamSource!!
-                                onShowToast("元のストリーミングソースに復帰しました")
-                            }
-                            ps.previousStreamSource = null
-                        }
+                        exitDualDisplayMode()
                     }
                 },
                 onSwapScreens = {
@@ -827,6 +951,7 @@ fun LivePlayerScreen(
                     }
                 },
                 availableQualities = availableQualities,
+                allowHeavyDual = allowMirakurunDual == "ON",
                 focusRequester = subMenuFocusRequester,
                 onSourceSelect = { source, isDirect ->
                     ps.currentStreamSource = source

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/LivePlayerState.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/LivePlayerState.kt
@@ -73,6 +73,10 @@ class LivePlayerState(
 
     var previousStreamSource by mutableStateOf<StreamSource?>(null)
 
+    // ★ 追加: KonomiTVのoriginal画質選択中にデュアル表示/PiPへ入った際の自動ダウングレード用。
+    // originalはソース自体はKonomiTVのままなので、previousStreamSourceと違い画質のみを退避・復元する
+    var previousQuality by mutableStateOf<StreamQuality?>(null)
+
     var lCropEnabled by mutableStateOf(false)
     var lCropMode by mutableStateOf(LCropMode.HIDDEN)
     var lCropZoom by mutableFloatStateOf(100f)

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/LivePlayerSubMenu.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/LivePlayerSubMenu.kt
@@ -68,7 +68,12 @@ fun LiveTopSubMenuUI(
     onCommentToggle: () -> Unit,
     onLCropToggle: () -> Unit,
     onCloseMenu: () -> Unit,
-    availableQualities: List<StreamQuality> = StreamQuality.DEFAULT_QUALITIES
+    availableQualities: List<StreamQuality> = StreamQuality.DEFAULT_QUALITIES,
+    // ★ 追加: 設定画面ラボの「Mirakurun/EDCB等の重量パイプラインでの2画面表示を許可」リミッターと
+    // 同じ設定値。originalもMIRAKURUN/EDCB同様の重量な生TSパイプラインを使うため、この設定でリミッター
+    // を解除しているユーザーには1080p系と違って除外せず選択可能にする(LivePlayerScreen.kt側の
+    // 自動ダウングレード判定と揃える)
+    allowHeavyDual: Boolean = false
 ) {
     val colors = KomorebiTheme.colors
     var selectedCategory by remember { mutableStateOf<LiveSubMenuCategory?>(null) }
@@ -77,19 +82,25 @@ fun LiveTopSubMenuUI(
     val mainSourceButtonRequester = remember { FocusRequester() }
 
     // ★ 修正: name を value に変更して Unresolved reference エラーを解消
-    val effectiveQualities = remember(isDualDisplayMode, availableQualities) {
+    // ★ 追加: original(MPEG-2)は1080相当以上の解像度かつHWデコーダーを専有するため、
+    // デュアル表示時は1080pと同様に選択肢から除外する。ただしallowHeavyDual(ラボのリミッター解除)が
+    // 有効な場合は、MIRAKURUN/EDCB同様に除外しない
+    val effectiveQualities = remember(isDualDisplayMode, availableQualities, allowHeavyDual) {
         if (isDualDisplayMode) {
-            availableQualities.filter { !it.value.contains("1080") && !it.label.contains("1080") }
+            availableQualities.filter {
+                !it.value.contains("1080") && !it.label.contains("1080") &&
+                    (allowHeavyDual || it.value != "original")
+            }
         } else {
             availableQualities
         }
     }
 
     // ★ 修正: name を value に変更して Unresolved reference エラーを解消
-    val effectiveQuality = remember(currentQuality, isDualDisplayMode, effectiveQualities) {
+    val effectiveQuality = remember(currentQuality, isDualDisplayMode, effectiveQualities, allowHeavyDual) {
         if (isDualDisplayMode && (currentQuality.value.contains("1080") || currentQuality.label.contains(
                 "1080"
-            ))
+            ) || (!allowHeavyDual && currentQuality.value == "original"))
         ) {
             effectiveQualities.find { it.value.contains("720") || it.label.contains("720") }
                 ?: effectiveQualities.firstOrNull()

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootBackground.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootBackground.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
+import androidx.compose.ui.focus.focusTarget
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -70,7 +71,25 @@ fun MainRootBackground(
         modifier = Modifier
             .fillMaxSize()
             .zIndex(0f)
-            .focusProperties { canFocus = !isFullScreenPlayerVisible }
+            // フルスクリーンのプレイヤー表示中は、背面ツリーへフォーカスが入り込まないよう完全に封鎖する。
+            //
+            // focusProperties { canFocus = false } だけでは不十分。Composeはフォーカス対象ノードが
+            // 自身の親をさかのぼる際「最初に見つかったフォーカス対象ノード」で打ち切って
+            // focusPropertiesを収集するため、間にLazyList等のfocusGroupが挟まる深い階層の項目
+            // (ホームのチャンネルカード等)にはcanFocus=falseが一切届かず、フォーカス可能なまま残る。
+            // 実際、プレイヤー側のフォーカスノードが破棄された(サブメニューを閉じた・二画面へ切り替えた等)
+            // タイミングでAndroidがフォーカスを再探索すると、背面ホーム画面の項目が選ばれてしまい、
+            // 「十字キーが無反応・決定キーだけ背面の項目に効く」という操作不能状態になっていた。
+            //
+            // onEnter { cancelFocusChange() } を持つフォーカスグループ(canFocus=false + focusTarget)に
+            // することで、このBox配下へのフォーカス侵入をフォーカス探索・明示的なrequestFocusの両方で拒否する。
+            .focusProperties {
+                canFocus = false
+                if (isFullScreenPlayerVisible) {
+                    onEnter = { cancelFocusChange() }
+                }
+            }
+            .focusTarget()
     ) {
             when {
                 state.isRecordListOpen -> {
@@ -291,7 +310,9 @@ fun MainRootBackground(
                         hasActivePlayer = state.isMiniPlayerMode,
                         onReturnToPlayerClick = { state.isMiniPlayerMode = false },
                         aiFocusReturnTick = state.aiFocusReturnTick,
-                        onAiReturnConsumed = { state.aiFocusReturnTick = 0 }
+                        onAiReturnConsumed = { state.aiFocusReturnTick = 0 },
+                        // プレイヤー表示中はホーム画面が見えないため、定期取得を止めさせる
+                        isPlayerActiveFullScreen = isFullScreenPlayerVisible
                     )
                 }
             }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootScreen.kt
@@ -399,7 +399,8 @@ fun MainRootScreen(
         state.isSettingsOpen = false; state.isDataReady = false; state.isUiReady =
         false; state.showConnectionErrorDialog = false
         state.currentTabIndex = 0
-        channelViewModel.fetchChannels(); epgViewModel.preloadAllEpgData(); homeViewModel.refreshHomeData()
+        // 設定変更を確実に反映させるため、間引きを無視して更新する。
+        channelViewModel.fetchChannels(); epgViewModel.preloadAllEpgData(); homeViewModel.refreshHomeData(force = true)
         recordViewModel.fetchRecentRecordings(forceRefresh = false); reserveViewModel.fetchReserves()
         state.settingsInitialCategoryIndex = 0
         state.settingsInitialFocusItemIndex = null

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/RecordListScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/RecordListScreen.kt
@@ -325,11 +325,24 @@ fun RecordListScreen(
         }
     }
 
+    // ★ 追加: プレイヤーへ遷移する直前に、開いているサブメニュー・ペイン類をすべて閉じる。
+    // この画面はプレイヤー表示中も破棄されずコンポーズされ続けるため（MainRootBackground参照）、
+    // 閉じずに再生を始めると復帰時にサブメニューが開いたまま残り、
+    // リスト側（LazyColumn の canFocus）へフォーカスを戻せなくなる。
+    val handleProgramClick: (RecordedProgram, Double?) -> Unit = { program, forcedPosition ->
+        menuState.closeAllMenus()
+        viewModel.clearProgramDetail()
+        onProgramClick(program, forcedPosition)
+    }
+
     // プレイヤー表示中もこの画面は背面で保持されるため、戻るたびに明示的に
     // 復帰チケットを発行する。これにより録画一覧・シリーズ検索結果の双方で、
     // 直前に再生していた番組へスクロールとフォーカスを戻せる。
     LaunchedEffect(isReturningFromPlayer, lastPlayedProgramId) {
         if (isReturningFromPlayer) {
+            // ★ 追加: onProgramClick を経由しない遷移（AIコンシェルジュ等）に備えた保険。
+            // メニューが開いたままだとフォーカス復帰チケットが効かない。
+            menuState.closeAllMenus()
             delay(150)
             if (lastPlayedProgramId != null) {
                 ticketManager.issue(FocusTicket.TARGET_ID, lastPlayedProgramId)
@@ -550,7 +563,7 @@ fun RecordListScreen(
                                     contentContainerFocusRequester = focuses.contentContainer,
                                     searchInputFocusRequester = focuses.searchInput,
                                     backButtonFocusRequester = focuses.backButton,
-                                    onProgramClick = onProgramClick,
+                                    onProgramClick = handleProgramClick,
                                     onSeriesSearch = { program ->
                                         viewModel.searchSeries(
                                             seriesId = program.seriesId,
@@ -561,6 +574,8 @@ fun RecordListScreen(
                                     },
                                     isDetailVisible = menuState.isDetailActive,
                                     onDetailStateChange = { menuState.isDetailActive = it },
+                                    isSideMenuOpen = menuState.isSideMenuOpen,
+                                    onSideMenuStateChange = { menuState.isSideMenuOpen = it },
                                     onBackPress = handleBackPress,
                                     ticketManager = ticketManager,
                                     listState = listState,
@@ -620,7 +635,7 @@ fun RecordListScreen(
                                     contentContainerFocusRequester = focuses.contentContainer,
                                     searchInputFocusRequester = focuses.searchInput,
                                     backButtonFocusRequester = focuses.backButton,
-                                    onProgramClick = onProgramClick,
+                                    onProgramClick = handleProgramClick,
                                     onOpenNavPane = handleOpenNavPane,
                                     ticketManager = ticketManager,
                                     onFocusedItemChanged = {

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/RecordListState.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/RecordListState.kt
@@ -100,8 +100,35 @@ class RecordListMenuState {
     var isNavFocused by mutableStateOf(false)
     var isPaneListReady by mutableStateOf(false)
 
+    // ★ 追加: リスト項目の右側に出るサブメニュー（再生する／最初から再生 等）の開閉状態。
+    // 以前は RecordListContent 内の remember で保持していたが、プレイヤー表示中も
+    // 録画一覧が Compose ツリーに残るようになったため、画面側から明示的に
+    // 閉じられるようここへホイストしている。
+    var isSideMenuOpen by mutableStateOf(false)
+
     val isPaneOpen: Boolean
         get() = isGenrePaneOpen || isSeriesGenrePaneOpen || isChannelPaneOpen || isDayPaneOpen
+
+    /**
+     * 開いているメニュー・ペイン類をすべて閉じる。
+     *
+     * プレイヤーへ遷移する直前と、プレイヤーから戻った直後に呼び出す。
+     * 録画一覧はプレイヤー表示中も破棄されずコンポーズされ続けるため、
+     * これを行わないとサブメニューが開いたまま復帰し、
+     * リスト側のフォーカス（LazyColumn の canFocus）がブロックされたままになる。
+     *
+     * 検索バーの表示状態（isSearchBarVisible）は検索結果の文脈を保つため意図的に触らない。
+     */
+    fun closeAllMenus() {
+        isNavPaneOpen = false
+        isGenrePaneOpen = false
+        isSeriesGenrePaneOpen = false
+        isChannelPaneOpen = false
+        isDayPaneOpen = false
+        isDetailActive = false
+        isSortMenuOpen = false
+        isSideMenuOpen = false
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/components/RecordListContent.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/components/RecordListContent.kt
@@ -75,6 +75,10 @@ fun RecordListContent(
     onSeriesSearch: (RecordedProgram) -> Unit,
     isDetailVisible: Boolean,
     onDetailStateChange: (Boolean) -> Unit,
+    // ★ 追加: サブメニューの開閉状態は呼び出し元（RecordListScreen）へホイストした。
+    // プレイヤー表示中も本画面が破棄されないため、遷移時に外から閉じられる必要がある。
+    isSideMenuOpen: Boolean,
+    onSideMenuStateChange: (Boolean) -> Unit,
     onBackPress: () -> Unit,
     ticketManager: FocusTicketManager,
     listState: LazyListState = rememberLazyListState(),
@@ -95,8 +99,12 @@ fun RecordListContent(
 
     var focusedProgram by remember { mutableStateOf<RecordedProgram?>(null) }
     var detailProgram by remember { mutableStateOf<RecordedProgram?>(null) }
-    var isSideMenuOpen by remember { mutableStateOf(false) }
     val backendType by settingViewModel.backendType.collectAsState()
+
+    // サブメニューが閉じられたら、詳細パネル用に保持していた番組も破棄する
+    LaunchedEffect(isSideMenuOpen) {
+        if (!isSideMenuOpen) detailProgram = null
+    }
 
     val itemFocusRequesters = remember { mutableMapOf<Int, FocusRequester>() }
     val menuFirstItemRequester = remember { FocusRequester() }
@@ -207,7 +215,7 @@ fun RecordListContent(
                             .onKeyEvent { event ->
                                 if (event.type == KeyEventType.KeyDown) {
                                     if (event.key == Key.DirectionRight) {
-                                        if (!isScrollInProgress) isSideMenuOpen = true
+                                        if (!isScrollInProgress) onSideMenuStateChange(true)
                                         return@onKeyEvent true
                                     } else if (event.key == Key.DirectionLeft) {
                                         if (!isScrollInProgress) onOpenNavPane()
@@ -277,7 +285,7 @@ fun RecordListContent(
                                     onClearDetail()
                                     scope.launch { delay(50); detailButtonFocusRequester.safeRequestFocus() }
                                 } else {
-                                    isSideMenuOpen = false
+                                    onSideMenuStateChange(false)
                                     val id = focusedProgram?.id
                                     if (id != null) {
                                         ticketManager.issue(FocusTicket.TARGET_ID, id)
@@ -386,7 +394,7 @@ fun RecordListContent(
                                     onClick = {
                                         focusedProgram?.let {
                                             onSeriesSearch(it)
-                                            isSideMenuOpen = false
+                                            onSideMenuStateChange(false)
                                         }
                                     })
                                 Spacer(Modifier.height(12.dp))
@@ -402,7 +410,7 @@ fun RecordListContent(
                                     onClick = {
                                         focusedProgram?.let {
                                             if (!isAlreadyAutoReserved && displayTitle.isNotBlank()) {
-                                                isSideMenuOpen = false
+                                                onSideMenuStateChange(false)
                                                 onAutoReserveClick(it)
                                             }
                                         }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/player/VideoPlayerManager.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/player/VideoPlayerManager.kt
@@ -20,13 +20,13 @@ import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
-import androidx.media3.common.Metadata
 import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.VideoSize
 import androidx.media3.common.Tracks
 import androidx.media3.common.TrackSelectionOverride
+import androidx.media3.common.util.TimestampAdjuster
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DataSpec
@@ -36,13 +36,16 @@ import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
 import androidx.media3.extractor.DefaultExtractorsFactory
-import androidx.media3.extractor.metadata.id3.PrivFrame
+import androidx.media3.extractor.Extractor
+import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.ts.DefaultTsPayloadReaderFactory
 import androidx.media3.extractor.ts.TsExtractor
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.exoplayer.upstream.DefaultAllocator
 import com.beeregg2001.komorebi.NativeLib
+import com.beeregg2001.komorebi.ui.live.DirectSubtitlePayloadReaderFactory
 import com.beeregg2001.komorebi.ui.subtitle.NativeCaptionCue
 import com.beeregg2001.komorebi.ui.subtitle.NativeCaptionDecoder
 import com.beeregg2001.komorebi.ui.subtitle.NativeCaptionLanguage
@@ -96,6 +99,23 @@ fun rememberManagedExoPlayer(
     settingsViewModel: SettingsViewModel = hiltViewModel()
 ): ManagedPlayerHandles {
     val captionDecoder = remember { NativeCaptionDecoder() }
+
+    // ★ 追加: HTTPレスポンスから得たファイル全体サイズ(シーク先バイト位置の計算に必要)。
+    // VideoPlayerScreen.kt側のシーク処理からも参照できるよう、ExoPlayer本体とは別にremember する。
+    val fileSizeBytesRef = remember { AtomicLong(0L) }
+
+    // ★ 追加: 直接TS再生のシーク先バイト位置の予約値(-1=予約なし)。ExoPlayerのSeekMap機構には
+    // 頼らず、シーク要求のたびにアプリ側でこの値をセットしてからMediaItemを作り直すことで、
+    // TsReadExDataSource.open()がposition=0の代わりにこの値から読み始めるようにする。
+    val pendingSeekByteRef = remember { AtomicLong(-1L) }
+
+    // ★ 修正: シークのたびに作り直される CServiceFilter の学習済み状態(PID構成/音声PTS-PCR差分)を
+    // DataSourceの再オープンをまたいで引き継ぐための共有変数。音声トラック切替時にMedia3内部が
+    // 発火させる「隠れシーク」で TsReadExDataSource.open() が再実行されても音ズレが再発しないようにする。
+    // 以前は exoPlayer の remember{} ブロック内で生成していたため、番組が切り替わってもクリアできず、
+    // 別番組の学習値が残り続けていた。番組切替時にクリアできるようComposable関数トップレベルに置く。
+    val filterStateRef = remember { AtomicReference<TsFilterStateSnapshot?>(null) }
+
     val clearSubtitle = {
         captionDecoder.flush()
         onSubtitleCue(
@@ -110,6 +130,17 @@ fun rememberManagedExoPlayer(
         )
     }
     LaunchedEffect(program?.id) {
+        // ★ 追加: 番組が切り替わったら、前番組のTS解析状態を必ず捨てる。
+        // これらは remember{} のライフタイム(=この画面が破棄されるまで)保持されるため、
+        // ミニプレイヤー表示中に別番組を選ぶなど「画面を破棄せずに番組だけが変わる」経路では
+        // 前番組の値が残り続け、
+        //  ・filterStateRef  … 別番組のPID構成/PTS-PCR差分を新しいCServiceFilterへ誤注入する
+        //  ・fileSizeBytesRef … 別番組のファイルサイズでシーク先バイト位置を誤計算する
+        //  ・pendingSeekByteRef … 消費されずに残った予約値で無関係なバイト位置から読み始める
+        // といった形で「再生が始まらない」不具合の原因になる。
+        filterStateRef.set(null)
+        fileSizeBytesRef.set(0L)
+        pendingSeekByteRef.set(-1L)
         captionDecoder.reset(subtitleLanguageId)
         onSubtitleLanguagesChanged(emptyList())
     }
@@ -126,6 +157,18 @@ fun rememberManagedExoPlayer(
     val backendType by settingsViewModel.backendType.collectAsState()
     val edcbPlayMethod by settingsViewModel.edcbRecordPlayMethod.collectAsState()
     val isEdcbDirect = (backendType == "EDCB" && edcbPlayMethod == "DIRECT")
+
+    // ★ 修正: 下の exoPlayer は キー無しの remember{} で生成されるため、そのブロック内のラムダ
+    // (dataSourceFactory)は「初回コンポジション時点の値」を永久にキャプチャしてしまう。
+    // program / isEdcbDirect / cfAccessHeaders はいずれも後から変わり得る値なので、
+    // rememberUpdatedState 経由で常に最新値を読むようにする。
+    //  ・program: tsreadex の -n(サービスID)に使う。番組が変わったのに古いサービスIDを渡すと
+    //    CServiceFilter が PAT 内に該当 program_number を見つけられず、全PIDを0にリセットし続け、
+    //    映像・音声を一切出力しない(=再生が永久に始まらない)。
+    //  ・isEdcbDirect / cfAccessHeaders: 設定の非同期読み込み完了前に確定してしまうのを防ぐ。
+    val currentProgramState by rememberUpdatedState(program)
+    val currentIsEdcbDirect by rememberUpdatedState(isEdcbDirect)
+    val currentCfAccessHeaders by rememberUpdatedState(cfAccessHeaders)
 
     val applyAudioSelectionAndMatrix = { mode: AudioMode, player: ExoPlayer ->
         val audioGroups = player.currentTracks.groups.filter { it.type == C.TRACK_TYPE_AUDIO }
@@ -164,15 +207,6 @@ fun rememberManagedExoPlayer(
         }
     }
 
-    // ★ 追加: HTTPレスポンスから得たファイル全体サイズ(シーク先バイト位置の計算に必要)。
-    // VideoPlayerScreen.kt側のシーク処理からも参照できるよう、ExoPlayer本体とは別にremember する。
-    val fileSizeBytesRef = remember { AtomicLong(0L) }
-
-    // ★ 追加: 直接TS再生のシーク先バイト位置の予約値(-1=予約なし)。ExoPlayerのSeekMap機構には
-    // 頼らず、シーク要求のたびにアプリ側でこの値をセットしてからMediaItemを作り直すことで、
-    // TsReadExDataSource.open()がposition=0の代わりにこの値から読み始めるようにする。
-    val pendingSeekByteRef = remember { AtomicLong(-1L) }
-
     val exoPlayer = remember {
         val renderersFactory = DefaultRenderersFactory(context).apply {
             setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON)
@@ -193,11 +227,6 @@ fun rememberManagedExoPlayer(
         // ★ 追加: 再生エラーの連続リトライ回数を保持(ファイル消失以外の一時的エラー用)
         var playerRetryCount = 0
 
-        // ★ 追加: シークのたびに作り直される CServiceFilter の学習済み状態(PID構成/音声PTS-PCR差分)を
-        // DataSourceの再オープンをまたいで引き継ぐための共有変数。音声トラック切替時にMedia3内部が
-        // 発火させる「隠れシーク」で TsReadExDataSource.open() が再実行されても音ズレが再発しないようにする。
-        val filterStateRef = AtomicReference<TsFilterStateSnapshot?>(null)
-
         val dataSourceFactory = DataSource.Factory {
             object : DataSource {
                 private var activeDataSource: DataSource? = null
@@ -213,8 +242,21 @@ fun rememberManagedExoPlayer(
                         ".ts",
                         ignoreCase = true
                     ) == true || dataSpec.uri.path?.endsWith("m2ts", ignoreCase = true) == true
+                    // ★ 追加: KonomiTVのoriginal画質(MPEG-2直接再生)は、録画ファイルダウンロードAPI
+                    // (/api/videos/{id}/download)をそのまま生MPEG-TSソースとして使う。拡張子が
+                    // .ts/.m2tsではないURL形式のため、isDirectTsとは別に判定する。
+                    val isKonomiOriginal = dataSpec.uri.path?.let {
+                        it.contains("/api/videos/") && it.endsWith("/download")
+                    } == true
 
-                    val sid = program?.channel?.serviceId ?: -1
+                    // ★ 修正(再修正): 一度 "0"(フィルタなし)にフォールバックさせたが、KonomiTV
+                    // サーバー側(VideoEncodingTask.py)を確認したところ、channelがnull(SDT解析失敗)の
+                    // 録画でも同じ"-1"(PMTの1番目のプログラムを選ぶ)にフォールバックしており、
+                    // それで実際に字幕が出ている(HLS側で確認済み)。つまり"-1"自体は正しい選択で、
+                    // 元の実装が正しかった。字幕欠落の原因は別にあるため、"-1"に戻す。
+                    // ★ 修正: 初回コンポジション時にキャプチャした古い program ではなく、
+                    // 常に最新の番組のサービスIDを tsreadex へ渡す(上のrememberUpdatedStateのコメント参照)
+                    val sid = currentProgramState?.channel?.serviceId ?: -1
                     val nValue = sid.toString()
 
                     val dynamicTsArgs = arrayOf(
@@ -222,14 +264,14 @@ fun rememberManagedExoPlayer(
                         "-a", "13", "-b", "5", "-c", "5", "-u", "1", "-d", "13"
                     )
 
-                    val source = if (isEdcbScheme || isDirectTs || isEdcbDirect) {
+                    val source = if (isEdcbScheme || isDirectTs || currentIsEdcbDirect || isKonomiOriginal) {
                         // ★ 修正: ファイルサイズ格納用の参照とCloudflare Accessヘッダー、
                         // 音声PTS-PCR学習状態の引き継ぎ用参照、シーク先バイト位置の予約値を渡す
                         TsReadExDataSource(
                             nativeLib,
                             dynamicTsArgs,
                             fileSizeBytesRef,
-                            cfAccessHeaders,
+                            currentCfAccessHeaders,
                             filterStateRef,
                             pendingSeekByteRef
                         )
@@ -261,11 +303,39 @@ fun rememberManagedExoPlayer(
         // 実機で確認された。この方式は廃止し、TsExtractorの自動判定(sniff)・初期化をそのまま信頼する。
         // シークは ExoPlayer の SeekMap 経由ではなく、アプリ側(VideoPlayerScreen.kt)で目標バイト位置を
         // 計算して MediaItem を作り直す方式(pendingSeekByteRef 経由)で行う。
-        val extractorsFactory = DefaultExtractorsFactory().apply {
-            setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ALLOW_NON_IDR_KEYFRAMES or DefaultTsPayloadReaderFactory.FLAG_DETECT_ACCESS_UNITS)
-            setTsExtractorTimestampSearchBytes(2 * 1024 * 1024)
-            setTsExtractorMode(TsExtractor.MODE_SINGLE_PMT)
-            setMatroskaExtractorFlags(MatroskaExtractor.FLAG_DISABLE_SEEK_FOR_CUES)
+
+        // ★ 修正: 字幕不具合の根本原因が判明したため対応。Media3標準のId3Reader(stream_type 0x15)
+        // /onMetadataに頼る経路は、id3conv.cppが生成するID3化PESに対して機能しない(native側は
+        // CheckPrivateDataPes ACCEPTEDが出続けており変換自体は正常なのに、onMetadataが一度も
+        // 呼ばれないことを実機ログで確認済み)。一方、ライブ視聴(LivePlayerViewModel.kt)は元々
+        // Media3標準経路を使わず、TsPayloadReader.consume()でPESペイロードを自前バイトスキャンする
+        // DirectSubtitlePayloadReaderFactory方式を採用しており、二画面ライブでも字幕表示が実機で
+        // 確認できている。録画/EDCB直接/KonomiTV Original再生もこの実績のある方式に統一する。
+        val onSubtitleDataReceived: (Long, ByteArray) -> Unit = { ptsMs, privateData ->
+            val cue = captionDecoder.decode(privateData, ptsMs, renderCaptions = vs.isSubtitleEnabled)
+            onSubtitleLanguagesChanged(captionDecoder.availableLanguages())
+            if (vs.isSubtitleEnabled && cue != null) onSubtitleCue(cue)
+        }
+
+        val extractorsFactory = ExtractorsFactory {
+            // stream_type 0x06/0x15(字幕/ID3)以外は従来通りDefaultTsPayloadReaderFactory等に委譲する。
+            // TsExtractorの重複を避けるため、フォールバック配列からは除外しておく
+            // (このExoPlayerインスタンスでProgressiveMediaSourceが選ばれるのは直接TS再生時のみのため、
+            // 実質的にフォールバックが使われることはない想定だが、安全側に倒して残しておく)。
+            val fallbackExtractors = DefaultExtractorsFactory().apply {
+                setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ALLOW_NON_IDR_KEYFRAMES or DefaultTsPayloadReaderFactory.FLAG_DETECT_ACCESS_UNITS)
+                setTsExtractorTimestampSearchBytes(2 * 1024 * 1024)
+                setTsExtractorMode(TsExtractor.MODE_SINGLE_PMT)
+                setMatroskaExtractorFlags(MatroskaExtractor.FLAG_DISABLE_SEEK_FOR_CUES)
+            }.createExtractors().filterNot { it is TsExtractor }.toTypedArray()
+            arrayOf<Extractor>(
+                TsExtractor(
+                    TsExtractor.MODE_SINGLE_PMT,
+                    TimestampAdjuster(0L),
+                    DirectSubtitlePayloadReaderFactory(onSubtitleDataReceived = onSubtitleDataReceived),
+                    2 * 1024 * 1024
+                )
+            ) + fallbackExtractors
         }
 
         val mediaSourceFactory =
@@ -364,20 +434,6 @@ fun rememberManagedExoPlayer(
                         }
                     }
 
-                    override fun onMetadata(metadata: Metadata) {
-                        for (i in 0 until metadata.length()) {
-                            val entry = metadata.get(i)
-                            if (entry is PrivFrame && (entry.owner.contains("aribb24", true) || entry.owner.contains("B24", true))) {
-                                val cue = captionDecoder.decode(
-                                    entry.privateData,
-                                    currentPosition,
-                                    renderCaptions = vs.isSubtitleEnabled
-                                )
-                                onSubtitleLanguagesChanged(captionDecoder.availableLanguages())
-                                if (vs.isSubtitleEnabled && cue != null) onSubtitleCue(cue)
-                            }
-                        }
-                    }
                 })
             }
     }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/video/player/VideoPlayerScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/video/player/VideoPlayerScreen.kt
@@ -67,6 +67,16 @@ private val EPG_STATION_DIRECT_VIDEO_REGEX = Regex("/api/videos/\\d+$")
 private fun isEpgStationDirectVideoUrl(url: String): Boolean =
     EPG_STATION_DIRECT_VIDEO_REGEX.containsMatchIn(url.substringBefore("?"))
 
+/**
+ * KonomiTV の original画質(MPEG-2直接再生)用URL (`/api/videos/{id}/download`) かどうかを判定する。
+ * EPGStationの無変換再生URLと同様、HLSではなく生MPEG-TSがそのまま流れてくるため、
+ * (下のURLパターンマッチで)HLSとして誤解釈させてはいけない。
+ */
+private val KONOMI_TV_ORIGINAL_VIDEO_REGEX = Regex("/api/videos/\\d+/download$")
+
+private fun isKonomiTvOriginalVideoUrl(url: String): Boolean =
+    KONOMI_TV_ORIGINAL_VIDEO_REGEX.containsMatchIn(url.substringBefore("?"))
+
 @UnstableApi
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -116,7 +126,7 @@ fun VideoPlayerScreen(
     LaunchedEffect(program.id) {
         if (smbItem == null) {
             videoPlayerViewModel.fetchProgramDetail(program.id)
-            videoPlayerViewModel.fetchAvailableQualities()
+            videoPlayerViewModel.fetchAvailableQualities(program.id)
         }
     }
 
@@ -244,6 +254,9 @@ fun VideoPlayerScreen(
     val backendType by settingsViewModel.backendType.collectAsState()
     val edcbPlayMethod by settingsViewModel.edcbRecordPlayMethod.collectAsState()
     val isEdcbDirect = (backendType == "EDCB" && edcbPlayMethod == "DIRECT")
+    // ★ 追加: KonomiTVのoriginal画質(MPEG-2直接再生)も、EDCB直接再生と同じくExoPlayerの
+    // SeekMapに頼らないバイト位置計算シーク方式で扱う必要がある
+    val isKonomiOriginal = (backendType == "KONOMITV" && vs.currentQuality.value == "original")
 
     // ★ 修正: 録画直接TS再生(isEdcbDirect)は、ExoPlayerのSeekMap機構(seekTo())に頼らず、
     // シーク要求のたびにアプリ側で目標バイト位置を計算してMediaItemを作り直す方式にした
@@ -266,7 +279,7 @@ fun VideoPlayerScreen(
         onStopOrDispose = { player ->
             if (smbItem == null) {
                 val posMs =
-                    if (isOffsetBasedStream || isEdcbDirect) vs.playbackOffsetMs + player.currentPosition else player.currentPosition
+                    if (isOffsetBasedStream || isEdcbDirect || isKonomiOriginal) vs.playbackOffsetMs + player.currentPosition else player.currentPosition
                 videoPlayerViewModel.updateWatchHistory(program, posMs / 1000.0)
             }
         },
@@ -283,7 +296,7 @@ fun VideoPlayerScreen(
     // 実況コメントの追従位置がズレ続ける不具合があった。performSeek等と同様、毎回の
     // リコンポジションで最新の値を捕捉する普通のラムダにする(memo化するほど重い処理ではない)。
     val getCurrentPositionMs: () -> Long =
-        { if (isOffsetBasedStream || isEdcbDirect) vs.playbackOffsetMs + exoPlayer.currentPosition else exoPlayer.currentPosition }
+        { if (isOffsetBasedStream || isEdcbDirect || isKonomiOriginal) vs.playbackOffsetMs + exoPlayer.currentPosition else exoPlayer.currentPosition }
     val subtitleCue = rememberNativeCaptionCue(
         events = subtitleEvents,
         enabled = vs.isSubtitleEnabled,
@@ -336,8 +349,8 @@ fun VideoPlayerScreen(
                 )
                 if (newUrl.isNotEmpty()) {
                     val mediaItemBuilder = MediaItem.Builder().setUri(newUrl)
-                    if (isEpgStationDirectVideoUrl(newUrl)) {
-                        // EPGStation の無変換再生は MPEG-TS がそのまま流れてくる (HLS ではない)
+                    if (isEpgStationDirectVideoUrl(newUrl) || isKonomiTvOriginalVideoUrl(newUrl)) {
+                        // EPGStation/KonomiTVの無変換(original)再生はMPEG-TSがそのまま流れてくる (HLSではない)
                         mediaItemBuilder.setMimeType(MimeTypes.VIDEO_MP2T)
                     } else if (newUrl.contains("/api/streams/") || newUrl.contains("/api/videos/") || newUrl.contains(
                             "konomi.tv"
@@ -352,7 +365,7 @@ fun VideoPlayerScreen(
                     if (fetchedDetail != null) onShowToast("シーク先ストリームの取得に失敗しました")
                 }
             }
-        } else if (isEdcbDirect && smbItem == null) {
+        } else if ((isEdcbDirect || isKonomiOriginal) && smbItem == null) {
             // ★ 追加: 録画直接TS再生のシークはExoPlayerネイティブのseekTo()に頼らず、
             // 目標バイト位置を計算してMediaItemを作り直す(VideoPlayerManager.kt参照)
             val byteOffset = computeSeekByteOffset(safeTarget)
@@ -424,7 +437,16 @@ fun VideoPlayerScreen(
 
     var isFirstLoad by remember { mutableStateOf(true) }
 
-    LaunchedEffect(currentProgram.id, smbItem, vs.currentQuality, availableQualities) {
+    // ★ 修正: 以前は isQualitiesLoaded がキーに含まれておらず、本文中でガード条件にだけ
+    // 使われていた。availableQualities の更新(再取得完了)と isQualitiesLoaded が true に
+    // 戻るタイミングがわずかにズレるレースがあり、
+    //  1. availableQualities の参照更新でこのeffectが再起動される
+    //  2. その瞬間はまだ isQualitiesLoaded=false(再取得の過渡状態)のため早期return
+    //  3. 直後に isQualitiesLoaded が true に戻るが、キーに含まれていないため
+    //     effectは再発火せず、再生開始処理(setMediaItem/prepare/play)が永久に走らない
+    // という不具合があった(実機ログで確認済み)。isQualitiesLoaded をキーに追加し、
+    // trueに戻った時点で確実にeffectが再評価されるようにする。
+    LaunchedEffect(currentProgram.id, smbItem, vs.currentQuality, availableQualities, isQualitiesLoaded) {
         if (smbItem != null) {
             isBuffering = true
             vs.playbackOffsetMs = 0L
@@ -459,8 +481,8 @@ fun VideoPlayerScreen(
 
         if (url.isNotEmpty()) {
             val mediaItemBuilder = MediaItem.Builder().setUri(url)
-            if (isEpgStationDirectVideoUrl(url)) {
-                // EPGStation の無変換再生は MPEG-TS がそのまま流れてくる (HLS ではない)
+            if (isEpgStationDirectVideoUrl(url) || isKonomiTvOriginalVideoUrl(url)) {
+                // EPGStation/KonomiTVの無変換(original)再生はMPEG-TSがそのまま流れてくる (HLSではない)
                 mediaItemBuilder.setMimeType(MimeTypes.VIDEO_MP2T)
             } else if (url.contains("/api/streams/") || url.contains("/api/videos/") || url.contains("konomi.tv") || url.contains(
                     "m3u8"
@@ -470,14 +492,14 @@ fun VideoPlayerScreen(
             }
             val mediaItem = mediaItemBuilder.build()
             exoPlayer.setMediaItem(mediaItem)
-            if (isFirstLoad && initialPositionMs > 0 && !isOffsetBasedStream && !isEdcbDirect) {
+            if (isFirstLoad && initialPositionMs > 0 && !isOffsetBasedStream && !isEdcbDirect && !isKonomiOriginal) {
                 exoPlayer.seekTo(initialPositionMs)
             }
             // ★ 追加: 直接TS再生はExoPlayerネイティブのseekTo()が使えないため、初回再生位置の
             // 復元はここではできない。ファイルサイズが判明してからバイト位置ベースで
             // シークし直す(下のscope.launch参照)。
             val shouldResumeViaByteSeek =
-                isEdcbDirect && isFirstLoad && initialPositionMs > 0
+                (isEdcbDirect || isKonomiOriginal) && isFirstLoad && initialPositionMs > 0
             isFirstLoad = false
             exoPlayer.prepare()
             exoPlayer.playWhenReady = true
@@ -800,7 +822,11 @@ fun VideoPlayerScreen(
                             videoPlayerViewModel.saveVideoQuality(it.value)
                             val player = exoPlayer
                             val currentPos = getCurrentPositionMs()
-                            if (isEdcbDirect) {
+                            // ★ 追加: isKonomiOriginalは切替前(vs.currentQuality代入前)の値を
+                            // 参照するため、ここでは切替先(it.value)から改めて判定する
+                            val isTargetKonomiOriginal =
+                                backendType == "KONOMITV" && it.value == "original"
+                            if (isEdcbDirect || isTargetKonomiOriginal) {
                                 // ★ 修正: 直接TS再生の画質切替後の位置復元もExoPlayerネイティブの
                                 // seekTo()には頼らず、目標バイト位置を計算してから再生を始める
                                 scope.launch {
@@ -912,7 +938,11 @@ fun VideoPlayerScreen(
                             videoPlayerViewModel.saveVideoQuality(it.value)
                             val player = exoPlayer
                             val currentPos = getCurrentPositionMs()
-                            if (isEdcbDirect) {
+                            // ★ 追加: isKonomiOriginalは切替前(vs.currentQuality代入前)の値を
+                            // 参照するため、ここでは切替先(it.value)から改めて判定する
+                            val isTargetKonomiOriginal =
+                                backendType == "KONOMITV" && it.value == "original"
+                            if (isEdcbDirect || isTargetKonomiOriginal) {
                                 // ★ 修正: 直接TS再生の画質切替後の位置復元もExoPlayerネイティブの
                                 // seekTo()には頼らず、目標バイト位置を計算してから再生を始める
                                 scope.launch {

--- a/app/src/main/java/com/beeregg2001/komorebi/util/TsReadExDataSource.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/util/TsReadExDataSource.kt
@@ -22,10 +22,13 @@ import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.locks.ReentrantLock
 import kotlin.concurrent.withLock
 
-// ★ CServiceFilterの学習済み状態(PID構成/PTS-PCR差分)と、それを取得した時点でのファイル内バイト位置を
-// セットで保持する。position はトラック切替時の「隠れリシーク」(=ほぼ同じ位置での再オープン)か、
-// 本物のシーク(=離れた位置への再オープン)かを判定するために使う(TsReadExDataSource.open()参照)。
-data class TsFilterStateSnapshot(val position: Long, val state: LongArray)
+// ★ CServiceFilterの学習済み状態(PID構成/PTS-PCR差分)と、それを取得した時点のストリームURL/
+// ファイル内バイト位置をセットで保持する。
+// - uri: 学習元のストリーム。別番組(=別URL)の学習値を誤って引き継がないための照合キー。
+//   PID構成もPTS-PCR差分も番組(TSファイル)ごとに異なるため、URLが違えば絶対に引き継いではいけない。
+// - position: トラック切替時の「隠れリシーク」(=ほぼ同じ位置での再オープン)か、
+//   本物のシーク(=離れた位置への再オープン)かを判定するために使う(TsReadExDataSource.open()参照)。
+data class TsFilterStateSnapshot(val uri: String, val position: Long, val state: LongArray)
 
 @UnstableApi
 class TsReadExDataSource(
@@ -55,7 +58,8 @@ class TsReadExDataSource(
     private var uri: Uri? = null
     private var opened = false
 
-    // ★ 診断用: open()時のバイト位置と、そこからの生バイト読み込み量(=現在のファイル内位置の推定)
+    // open()時のバイト位置と、そこからの生バイト読み込み量(=現在のファイル内位置の推定)。
+    // close()時にCServiceFilterの学習済み状態と合わせてfilterStateRefへ退避する際に使う。
     private var openPosition: Long = 0
     private var rawBytesRead: Long = 0
 
@@ -118,10 +122,16 @@ class TsReadExDataSource(
         // ただし、これはトラック切替時の「ほぼ同じ位置での再オープン」を想定した引き継ぎなので、
         // 離れた位置への本物のシークでは適用しない(別区間の学習値を誤って使うと、そこだけ
         // 音ズレが悪化したりデコードエラーの原因になり得るため)。
+        // さらに、退避元と今回のストリームURLが完全一致することも条件にする。番組を切り替えた場合は
+        // PID構成もPTS-PCR差分も全く別物になるため、位置がたまたま近くても引き継いではいけない
+        // (別番組のPID構成を注入すると、正しいPMTを拾い直すまで映像/音声が一切出力されず、
+        //  「再生が始まらない」不具合になる)。
+        val currentUri = dataSpec.uri.toString()
         val pending = filterStateRef?.get()
+        val isSameSource = pending != null && pending.uri == currentUri
         val isNearSamePosition = pending != null &&
             kotlin.math.abs(pending.position - effectivePosition) <= HIDDEN_RESEEK_TOLERANCE_BYTES
-        if (pending != null && isNearSamePosition) {
+        if (pending != null && isSameSource && isNearSamePosition) {
             nativeLib.importFilterState(handle, pending.state)
         }
 
@@ -320,6 +330,8 @@ class TsReadExDataSource(
     }
 
     override fun close() {
+        // ★ 学習済み状態の退避先(TsFilterStateSnapshot)に記録するため、uriをクリアされる前に控えておく
+        val closedUri = uri
         if (opened) {
             transferEnded(); opened = false
         }
@@ -341,7 +353,9 @@ class TsReadExDataSource(
                 // 次にこのDataSourceがほぼ同じ位置で開かれた際(隠れリシーク)に引き継げるようにする
                 val exported = nativeLib.exportFilterState(handle)
                 val finalPosition = openPosition + rawBytesRead
-                filterStateRef?.set(TsFilterStateSnapshot(finalPosition, exported))
+                filterStateRef?.set(
+                    TsFilterStateSnapshot(closedUri?.toString().orEmpty(), finalPosition, exported)
+                )
                 nativeLib.closeFilter(handle); handle = 0L
             }
         }

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/ChannelViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/ChannelViewModel.kt
@@ -303,6 +303,12 @@ class ChannelViewModel @Inject constructor(
 
     @RequiresApi(Build.VERSION_CODES.O)
     fun startPolling() {
+        // stopPolling() は progressUpdateJob も止めるが、以前はこちらを再開していなかったため、
+        // 一度でもライブ以外のタブへ移ると番組の進捗バーが二度と更新されなくなっていた。
+        if (progressUpdateJob?.isActive != true) {
+            startProgressUpdater()
+        }
+
         pollingJob?.cancel()
         pollingJob = viewModelScope.launch {
             if (System.currentTimeMillis() - lastFetchedTimeMillis > 60_000L && !isPollingPaused) {

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/HomeViewModel.kt
@@ -22,6 +22,7 @@ import com.google.gson.reflect.TypeToken
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.async
@@ -62,6 +63,18 @@ class HomeViewModel @Inject constructor(
 
     private val _isFallbackTriggered = MutableStateFlow(false)
     val isFallbackTriggered: StateFlow<Boolean> = _isFallbackTriggered.asStateFlow()
+
+    // refreshHomeData() は「バックエンド疎通確認 + 視聴履歴同期(Room書き込み) + EPG3日分の
+    // ジャンル再抽出」を行う重い処理。タブのフォーカス操作などから無制限に呼ばれると、
+    // 同じ処理が何本も並走して Android TV の非力な CPU / ネットワークを食い潰し、
+    // 画面全体の操作が緩慢になる。実行中の重複起動を弾き、直近実行からの経過時間でも間引く。
+    private var homeRefreshJob: Job? = null
+    private var lastHomeRefreshAt = 0L
+
+    companion object {
+        // ホーム更新の最小間隔。これより短い連続要求は無視する。
+        private const val HOME_REFRESH_MIN_INTERVAL_MS = 60_000L
+    }
 
     fun clearFocusMemory() {
         lastClickedSection = null
@@ -374,8 +387,25 @@ class HomeViewModel @Inject constructor(
         appUpdater.resetState()
     }
 
-    fun refreshHomeData() {
-        viewModelScope.launch {
+    /**
+     * ホーム画面のデータを更新する。
+     *
+     * @param force 設定変更後など、間引きを無視して必ず更新したい場合に true を指定する。
+     */
+    fun refreshHomeData(force: Boolean = false) {
+        // 実行中のものがあれば、それに任せて二重起動しない。
+        if (homeRefreshJob?.isActive == true) {
+            Log.d("HomeViewModel", "refreshHomeData: 実行中のため要求をスキップします")
+            return
+        }
+        val now = System.currentTimeMillis()
+        if (!force && now - lastHomeRefreshAt < HOME_REFRESH_MIN_INTERVAL_MS) {
+            Log.d("HomeViewModel", "refreshHomeData: 直近に実行済みのため要求をスキップします")
+            return
+        }
+        lastHomeRefreshAt = now
+
+        homeRefreshJob = viewModelScope.launch {
             _isLoading.value = true
             try {
                 performBackendHealthCheck()

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/LivePlayerViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/LivePlayerViewModel.kt
@@ -587,6 +587,7 @@ class LivePlayerViewModel @Inject constructor(
                             streamUrl,
                             source,
                             isEdcbDirect,
+                            quality,
                             mainTsDataSourceFactory,
                             ::decodeAndEmitMainSubtitle,
                             cfAccessHeaders
@@ -686,6 +687,7 @@ class LivePlayerViewModel @Inject constructor(
                             streamUrl,
                             source,
                             isEdcbDirect,
+                            quality,
                             dualTsDataSourceFactory,
                             ::decodeAndEmitDualSubtitle,
                             cfAccessHeaders
@@ -843,12 +845,41 @@ class LivePlayerViewModel @Inject constructor(
                 } else ""
             }
 
-            StreamSource.KONOMITV -> UrlBuilder.getKonomiTvLiveStreamUrl(
-                config.ip,
-                config.port,
-                channel.displayChannelId,
-                quality.value
-            )
+            StreamSource.KONOMITV -> {
+                // ★ 追加: original画質はサーバー側で再エンコードせず、tsreadexを通しただけの
+                // 生MPEG-TSがそのまま流れてくる。サーバー側tsreadexは-a/-b/-c/-uでPID存在保証は
+                // 行うがID3変換(-d)や音声デュアルモノ分離は行わないため、EDCB/Mirakurunの生放送波
+                // 直接再生と同じ状態(生PESの字幕・未分離の音声)。再エンコードを挟まないぶん
+                // program_number/service_idは放送そのままのはずなので、EDCB/Mirakurunと同様に
+                // channel.serviceIdでCServiceFilterに正しく対象サービスを絞らせ、音声デュアルモノ
+                // 分離とID3変換(id3convは独立してPMTからPIDを検出するためservice絞り込みの影響を
+                // 受けない)の両方を有効にする
+                if (quality.value == "original") {
+                    factory.tsArgs = arrayOf(
+                        "-x",
+                        "18/38/39",
+                        "-n",
+                        channel.serviceId.toString(),
+                        "-a",
+                        "13",
+                        "-b",
+                        "4",
+                        "-c",
+                        "5",
+                        "-u",
+                        "1",
+                        "-d",
+                        "13"
+                    )
+                    factory.requestHeaders = cfAccessHeaders
+                }
+                UrlBuilder.getKonomiTvLiveStreamUrl(
+                    config.ip,
+                    config.port,
+                    channel.displayChannelId,
+                    quality.value
+                )
+            }
 
             StreamSource.EPGSTATION -> {
                 // EPGStationのmode 1/2はトランスコード後にprogram numberが1へ
@@ -893,6 +924,7 @@ class LivePlayerViewModel @Inject constructor(
         streamUrl: String,
         source: StreamSource,
         isEdcbDirect: Boolean,
+        quality: StreamQuality,
         factory: TsReadExDataSourceFactory,
         onSubtitleDataReceived: (Long, ByteArray) -> Unit,
         cfAccessHeaders: Map<String, String> = emptyMap()
@@ -907,7 +939,12 @@ class LivePlayerViewModel @Inject constructor(
                     HlsMediaSource.Factory(httpDataSourceFactory)
                         .setAllowChunklessPreparation(false)
                         .createMediaSource(mediaItem)
-                } else if (source == StreamSource.MIRAKURUN || source == StreamSource.EPGSTATION || (source == StreamSource.EDCB && isEdcbDirect)) {
+                } else if (source == StreamSource.MIRAKURUN || source == StreamSource.EPGSTATION ||
+                    (source == StreamSource.EDCB && isEdcbDirect) ||
+                    // ★ 追加: KonomiTVのoriginal画質も生MPEG-TSなので同じ経路(TsReadExDataSource +
+                    // 直接PESパース)で再生する
+                    (source == StreamSource.KONOMITV && quality.value == "original")
+                ) {
                     val extractorsFactory = ExtractorsFactory {
                         arrayOf(
                             TsExtractor(

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/VideoPlayerViewModel.kt
@@ -78,7 +78,7 @@ class VideoPlayerViewModel @Inject constructor(
     private var detailFetchJob: Job? = null
     private var streamMaintenanceJob: Job? = null
 
-    fun fetchAvailableQualities() {
+    fun fetchAvailableQualities(videoId: Int) {
         viewModelScope.launch(Dispatchers.IO) {
             _isQualitiesLoaded.value = false
             try {
@@ -112,7 +112,25 @@ class VideoPlayerViewModel @Inject constructor(
                         }
                     }
                 } else if (backend == "KONOMITV") {
-                    _availableQualities.value = StreamQuality.DEFAULT_QUALITIES
+                    // ★ 追加: original画質(MPEG-2 直接再生)は、録画完了済み・かつ
+                    // コンテナがMPEG-TS・映像コーデックがMPEG-2の録画番組でのみ選択可能にする
+                    // (tsreplace等で既にH.264/HEVCへ変換済みの録画では利用不可。KonomiTVサーバー
+                    // 側もこの条件を満たさない場合は録画ダウンロードAPIをoriginal用途に使えない)。
+                    // 一覧画面のRoom DBキャッシュはcontainerFormat/videoCodecを保持していないため、
+                    // 必ずここでAPIから最新の詳細を取得して判定する。
+                    val isOriginalAvailable = recordProvider.getRecordedProgram(videoId)
+                        .getOrNull()
+                        ?.recordedVideo
+                        ?.let { video ->
+                            video.status != "Recording" &&
+                                video.containerFormat.equals("MPEG-TS", ignoreCase = true) &&
+                                video.videoCodec.equals("MPEG-2", ignoreCase = true)
+                        } ?: false
+                    _availableQualities.value = if (isOriginalAvailable) {
+                        StreamQuality.DEFAULT_QUALITIES
+                    } else {
+                        StreamQuality.DEFAULT_QUALITIES.filterNot { it.value == "original" }
+                    }
                 } else if (backend == "EPGSTATION") {
                     val qualities = recordProvider.getStreamQualities()
                     _availableQualities.value = qualities.ifEmpty {
@@ -326,6 +344,11 @@ class VideoPlayerViewModel @Inject constructor(
         currentPositionProvider: () -> Double
     ) {
         streamMaintenanceJob?.cancel()
+        // ★ 追加: KonomiTVのoriginal画質はHLS(VideoEncodingTask)のセッションを持たない単純な
+        // ファイルダウンロードのため、keep-alive API自体が存在しない(サーバー側は
+        // ValidateQualityで quality == 'original' を422で拒否する)。維持すべきセッションが
+        // ないので、無意味な失敗リクエストを4秒おきに送り続けないようループ自体を起動しない。
+        if (quality == "original") return
         streamMaintenanceJob = viewModelScope.launch(Dispatchers.IO) {
             while (isActive) {
                 try {


### PR DESCRIPTION
## 概要
KonomiTVのoriginal画質(生MPEG-TS直接再生)対応を追加し、実機検証を通じて見つかった一連のregressionを修正しました。

## 主な変更点
- KonomiTV original画質(ライブ/録画両対応)の実装(画質ピッカー、URL組み立て、EDCB直接再生方式のDataSourceルーティング)
- 録画/EDCB直接/Original再生で字幕が表示されない不具合を修正
  - Media3標準のId3Reader/onMetadataに依存する経路を、ライブ視聴で実績のあるDirectSubtitlePayloadReaderFactory方式に統一
  - id3conv.cppが生成するID3 PESのdata_alignment_indicatorビット不備を修正
- Original再生後に次の番組の再生が開始しない不具合を修正
  - LaunchedEffectのキー漏れ(isQualitiesLoaded)、program/isEdcbDirect/cfAccessHeadersのremember{}内クロージャ固定、filterStateRefの番組またぎ残留を修正
- 録画リストで再生後に戻るとサブメニューが開いたまま残りフォーカスが効かなくなる不具合を修正
- ホーム画面のタブ移動が緩慢な問題を修正(refreshHomeDataの多重起動防止・間引き、不要なFlow購読の削除、フルスクリーン再生中のポーリング停止)
- 二画面ライブ視聴のフォーカス漏れ・クロップ崩れを修正
- ラボ設定の二画面制限(labAllowMirakurunDual)をoriginal画質にも一貫適用

## 検証
- `./gradlew assembleDebug` ビルド成功
- 実機でのライブ/録画original画質再生、字幕表示・言語切替・二画面動作、再生後の再開、録画リストのフォーカス復帰を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)