### PR TITLE
fix: アプリ全体のパフォーマンス改善・PiPフォーカス不具合・EDCB画質不具合の修正

### DIFF
--- a/app/src/main/java/com/beeregg2001/komorebi/MainActivity.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/MainActivity.kt
@@ -33,8 +33,10 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         setTheme(R.style.Theme_Komorebi)
         super.onCreate(savedInstanceState)
+        ColdStartDiag.mark("MainActivity.onCreate")
 
         setContent {
+            LaunchedEffect(Unit) { ColdStartDiag.mark("setContent (first composition)") }
             KomorebiTheme {
                 var showExitDialog by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/beeregg2001/komorebi/MainApplication.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/MainApplication.kt
@@ -2,15 +2,33 @@ package com.beeregg2001.komorebi
 
 import android.app.Application
 // import android.content.res.Configuration <- これを削除しました
+import android.os.SystemClock
+import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import coil.disk.DiskCache
+import coil.memory.MemoryCache
+import coil.request.CachePolicy
 import com.beeregg2001.komorebi.data.api.interceptor.CloudflareAccessInterceptor
 import com.beeregg2001.komorebi.data.worker.RecordSyncWorker
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.OkHttpClient
 import javax.inject.Inject
+
+// ★ 追加(診断用): コールドブート直後の緩慢さの原因を実測するため、プロセス開始からの
+// 経過時間を主要な通過点でログ出力する。原因特定後は削除する想定の一時的な計測コード。
+// `adb logcat -s ColdStartDiag:I` で経過時間(ms)を直接確認できる。
+object ColdStartDiag {
+    private const val TAG = "ColdStartDiag"
+    private val processStartElapsedMs = SystemClock.elapsedRealtime()
+
+    fun mark(label: String) {
+        val elapsed = SystemClock.elapsedRealtime() - processStartElapsedMs
+        Log.i(TAG, "T+${elapsed}ms: $label")
+    }
+}
 
 @HiltAndroidApp
 class MainApplication : Application(), Configuration.Provider, ImageLoaderFactory {
@@ -22,6 +40,17 @@ class MainApplication : Application(), Configuration.Provider, ImageLoaderFactor
     lateinit var cloudflareAccessInterceptor: CloudflareAccessInterceptor
 
     // ★ 追加: Coil (AsyncImage) の画像取得にも Cloudflare Access ヘッダーを付与
+    // ★ 最適化: Android TV はメモリ・CPU ともに非力なため、Coil のデフォルト任せをやめて
+    //           メモリ／ディスクキャッシュを明示設定する。
+    //           - 局ロゴやサムネイルは「小さくて再利用頻度が極端に高い」画像なので、
+    //             メモリキャッシュを大きめ(25%)に固定する。Coil のデフォルトは
+    //             isLowRamDevice 判定で 15% まで落ちることがあり、TV 端末では
+    //             ロゴが即座に押し出されて毎回デコードし直す原因になっていた。
+    //           - respectCacheHeaders(false): KonomiTV / EPGStation / Mirakurun の
+    //             ロゴエンドポイントは no-cache 系ヘッダーを返すことがあり、
+    //             そのままだとディスクキャッシュがあっても毎回ネットワークへ出てしまう。
+    //             局ロゴは頻繁に変わらないためヘッダーを無視してキャッシュを優先する。
+    //           - crossfade(false): TV でのフェード合成は描画コストが高いため全体で無効化。
     override fun newImageLoader(): ImageLoader {
         return ImageLoader.Builder(this)
             .okHttpClient {
@@ -29,6 +58,21 @@ class MainApplication : Application(), Configuration.Provider, ImageLoaderFactor
                     .addInterceptor(cloudflareAccessInterceptor)
                     .build()
             }
+            .memoryCache {
+                MemoryCache.Builder(this)
+                    .maxSizePercent(0.25)
+                    .build()
+            }
+            .diskCache {
+                DiskCache.Builder()
+                    .directory(cacheDir.resolve("image_cache"))
+                    .maxSizeBytes(256L * 1024 * 1024)
+                    .build()
+            }
+            .memoryCachePolicy(CachePolicy.ENABLED)
+            .diskCachePolicy(CachePolicy.ENABLED)
+            .respectCacheHeaders(false)
+            .crossfade(false)
             .build()
     }
 
@@ -40,8 +84,19 @@ class MainApplication : Application(), Configuration.Provider, ImageLoaderFactor
 
     override fun onCreate() {
         super.onCreate()
+        ColdStartDiag.mark("MainApplication.onCreate")
 
-        // バックグラウンド同期スケジュールを登録
-        RecordSyncWorker.schedule(this)
+        // バックグラウンド同期スケジュールを登録する。
+        //
+        // WorkManager.getInstance() は初回呼び出し時に WorkManager 本体
+        // (Room DB の構成・ForceStopRunnable の起動など) を初期化するため、
+        // Application.onCreate から同期的に呼ぶと最初のフレームが描画されるまでの
+        // メインスレッドをそのぶん占有してしまう。
+        // 定期同期は 15 分間隔であり起動直後に即時実行する必要が一切ないので、
+        // 専用スレッドへ逃がして起動のクリティカルパスから外す。
+        Thread({ RecordSyncWorker.schedule(this) }, "komorebi-worker-schedule").apply {
+            priority = Thread.MIN_PRIORITY
+            start()
+        }
     }
 }

--- a/app/src/main/java/com/beeregg2001/komorebi/data/ChannelLogoUrlCache.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/ChannelLogoUrlCache.kt
@@ -1,0 +1,67 @@
+package com.beeregg2001.komorebi.data
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * 局ロゴ URL のプロセス全体で共有されるメモリキャッシュ。
+ *
+ * ■ なぜ必要か
+ * 局ロゴの URL 解決 (`LiveProvider.getChannelLogoUrl`) は suspend 関数で、バックエンドごとに
+ * 以下のような「見た目より重い」処理を行っている。
+ *   - KonomiTV : DataStore の Flow を 3 回 `first()` で読む (backendType / ip / port)
+ *   - EDCB     : Dispatchers.IO へ切り替え + キャッシュファイルの存在確認 (初回はダウンロード)
+ *   - EPGStation: Dispatchers.IO へ切り替え + ファイル存在確認 + チャンネル一覧の走査
+ *
+ * これがチャンネル一覧・番組表・ホームのカードなど「1 画面に数十個」並ぶ Composable から
+ * 個別に呼ばれていたため、リストのスクロールやタブ移動のたびに大量のコルーチン往復が発生していた。
+ * さらに Composable 側は解決完了まで空文字を表示するため、`"" -> URL` の 2 段階再コンポーズが
+ * 起こり、ロゴが一瞬消えてから出る「チラつき」の原因にもなっていた。
+ *
+ * ■ 設計
+ * - URL は「バックエンド種別が同じなら channelId から決定的に決まる」ため、
+ *   バックエンド種別をシグネチャとして保持し、変わったら全消しする。
+ * - Compose から同期的に初期値を取れるよう [peek] を提供する。ヒットすれば
+ *   最初のフレームから正しい URL で描画でき、チラつきと再コンポーズが消える。
+ * - 実体のキャッシュは Coil 側(メモリ/ディスク)が持つので、ここが持つのは URL 文字列だけ。
+ */
+object ChannelLogoUrlCache {
+
+    private val cache = ConcurrentHashMap<String, String>()
+
+    /** 現在キャッシュが有効なバックエンド種別。これが変わったらキャッシュ全体を破棄する。 */
+    @Volatile
+    private var signature: String = ""
+
+    /**
+     * Compose から同期的に呼ぶ用。解決済みなら URL、未解決なら null。
+     * バックエンド種別を知らなくても呼べるようにしてあるが、[sync] によって
+     * 古いバックエンドのエントリはすでに破棄されているため誤った URL は返らない。
+     */
+    fun peek(channelId: String): String? = cache[channelId]
+
+    fun get(backendType: String, channelId: String): String? {
+        sync(backendType)
+        return cache[channelId]
+    }
+
+    fun put(backendType: String, channelId: String, url: String) {
+        if (url.isEmpty()) return
+        sync(backendType)
+        cache[channelId] = url
+    }
+
+    /** 接続先設定が変わったときに呼ぶ。IP / ポート変更で URL が変わるため。 */
+    fun clear() {
+        cache.clear()
+    }
+
+    private fun sync(backendType: String) {
+        if (signature == backendType) return
+        synchronized(this) {
+            if (signature != backendType) {
+                cache.clear()
+                signature = backendType
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/beeregg2001/komorebi/data/api/interceptor/CloudflareAccessInterceptor.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/api/interceptor/CloudflareAccessInterceptor.kt
@@ -2,7 +2,13 @@ package com.beeregg2001.komorebi.data.api.interceptor
 
 import android.util.Log
 import com.beeregg2001.komorebi.data.SettingsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.Interceptor
@@ -17,33 +23,113 @@ import javax.inject.Singleton
  * トークンが未設定の場合は何もしない。
  * 認証情報の漏洩を防ぐため、設定された KonomiTV / Mirakurun / EPGStation サーバーの
  * ホスト宛のリクエストにのみヘッダーを付与する。
+ *
+ * ★ 性能上の注意:
+ * このインターセプターは API 通信だけでなく Coil (AsyncImage) の画像取得にも
+ * 適用される。以前は intercept() のたびに runBlocking で DataStore を読んでいたため、
+ * ホーム画面が局ロゴやサムネイルを何十枚も読み込む起動直後に、OkHttp のワーカースレッドが
+ * 毎回 DataStore の読み出し完了までブロックされていた (初回は実ディスク I/O)。
+ * 設定値は Flow で購読してキャッシュしておき、リクエスト経路からは同期読み出しを排除する。
  */
 @Singleton
 class CloudflareAccessInterceptor @Inject constructor(
     private val settingsRepository: SettingsRepository
 ) : Interceptor {
 
-    override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request()
-        val headers = runBlocking { settingsRepository.getCfAccessHeaders() }
-        if (headers.isEmpty()) return chain.proceed(request)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
-        val protectedHosts = runBlocking {
-            val ip = settingsRepository.konomiIp.first()
-            val port = settingsRepository.konomiPort.first()
-            val konomiBaseUrl = if (ip.startsWith("http://") || ip.startsWith("https://")) {
-                "$ip:$port"
-            } else {
-                "http://$ip:$port"
-            }
-            listOfNotNull(
-                konomiBaseUrl.toHttpUrlOrNull()?.host,
-                settingsRepository.getMirakurunBaseUrl()?.toHttpUrlOrNull()?.host,
-                // ★ 追加: EPGStation も Cloudflare Access 配下に置かれることがあるため対象に含める
-                settingsRepository.getEpgStationFullUrl().takeIf { it.isNotBlank() }
-                    ?.toHttpUrlOrNull()?.host
+    /** Cloudflare Access のヘッダー。未購読完了の間だけ null。 */
+    @Volatile
+    private var cachedHeaders: Map<String, String>? = null
+
+    /** ヘッダーを付与してよいホスト名。未購読完了の間だけ null。 */
+    @Volatile
+    private var cachedProtectedHosts: List<String>? = null
+
+    init {
+        scope.launch {
+            combine(
+                settingsRepository.cfAccessClientId,
+                settingsRepository.cfAccessClientSecret
+            ) { id, secret ->
+                SettingsRepository.buildCfAccessHeaders(id, secret)
+            }.distinctUntilChanged().collect { cachedHeaders = it }
+        }
+
+        scope.launch {
+            combine(
+                listOf(
+                    settingsRepository.konomiIp,
+                    settingsRepository.konomiPort,
+                    settingsRepository.mirakurunIp,
+                    settingsRepository.mirakurunPort,
+                    settingsRepository.epgStationIp,
+                    settingsRepository.epgStationPort
+                )
+            ) { values -> buildProtectedHosts(values.toList()) }
+                .distinctUntilChanged()
+                .collect { cachedProtectedHosts = it }
+        }
+    }
+
+    private fun buildProtectedHosts(values: List<String>): List<String> {
+        val (konomiIp, konomiPort) = values[0] to values[1]
+        val (mirakurunIp, mirakurunPort) = values[2] to values[3]
+        val (epgStationIp, epgStationPort) = values[4] to values[5]
+
+        val konomiBaseUrl = if (konomiIp.startsWith("http://") || konomiIp.startsWith("https://")) {
+            "$konomiIp:$konomiPort"
+        } else {
+            "http://$konomiIp:$konomiPort"
+        }
+
+        val mirakurunBaseUrl = if (mirakurunIp.isBlank()) {
+            null
+        } else if (mirakurunIp.startsWith("http://") || mirakurunIp.startsWith("https://")) {
+            "$mirakurunIp:$mirakurunPort"
+        } else {
+            "http://$mirakurunIp:$mirakurunPort"
+        }
+
+        val epgStationBaseUrl = if (epgStationIp.isBlank()) {
+            null
+        } else {
+            com.beeregg2001.komorebi.common.UrlBuilder.formatBaseUrl(
+                epgStationIp,
+                epgStationPort,
+                "http"
             )
         }
+
+        return listOfNotNull(
+            konomiBaseUrl.toHttpUrlOrNull()?.host,
+            mirakurunBaseUrl?.toHttpUrlOrNull()?.host,
+            // ★ 追加: EPGStation も Cloudflare Access 配下に置かれることがあるため対象に含める
+            epgStationBaseUrl?.takeIf { it.isNotBlank() }?.toHttpUrlOrNull()?.host
+        )
+    }
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+
+        // キャッシュが未充填なのは起動直後のごく短い間だけ。その場合のみ従来通り同期読みする。
+        val headers = cachedHeaders
+            ?: runBlocking { settingsRepository.getCfAccessHeaders() }.also { cachedHeaders = it }
+        if (headers.isEmpty()) return chain.proceed(request)
+
+        val protectedHosts = cachedProtectedHosts ?: runBlocking {
+            buildProtectedHosts(
+                listOf(
+                    settingsRepository.konomiIp.first(),
+                    settingsRepository.konomiPort.first(),
+                    settingsRepository.mirakurunIp.first(),
+                    settingsRepository.mirakurunPort.first(),
+                    settingsRepository.epgStationIp.first(),
+                    settingsRepository.epgStationPort.first()
+                )
+            )
+        }.also { cachedProtectedHosts = it }
+
         if (request.url.host !in protectedHosts) {
             return chain.proceed(request)
         }

--- a/app/src/main/java/com/beeregg2001/komorebi/data/repository/DtvProviderProxy.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/repository/DtvProviderProxy.kt
@@ -2,6 +2,7 @@ package com.beeregg2001.komorebi.data.repository
 
 import android.util.Log
 import androidx.media3.common.util.UnstableApi
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.SettingsRepository
 import com.beeregg2001.komorebi.data.model.*
 // ★ 追加: 分割された新しいEDCBリポジトリ群をインポート
@@ -99,9 +100,31 @@ class DtvProviderProxy @Inject constructor(
         }
     }
 
+    /**
+     * ★ 最適化: 局ロゴ URL をプロセス全体で共有するメモリキャッシュ経由で返す。
+     *
+     * 従来は呼び出し元ごと(ChannelViewModel のみ)にキャッシュがあり、EpgViewModel /
+     * HomeViewModel / LivePlayerViewModel、および各 Composable の LaunchedEffect からの
+     * 呼び出しは毎回バックエンドまで到達していた。バックエンド実装は DataStore 読み出しや
+     * Dispatchers.IO 切り替え + ファイル存在確認を伴うため、リスト描画のたびに
+     * 数十回のコルーチン往復が発生していた。
+     *
+     * キャッシュはバックエンド種別が変わると自動で破棄され、接続先(IP/ポート)変更時は
+     * SettingsRepository.saveString から明示的にクリアされる。
+     */
     override suspend fun getChannelLogoUrl(channelId: String): String {
         return try {
-            getLiveProvider().getChannelLogoUrl(channelId)
+            val backend = settingsRepository.backendType.first()
+            ChannelLogoUrlCache.get(backend, channelId)?.let { return it }
+
+            val provider = when (backend) {
+                "EDCB" -> edcbLiveRepository
+                "EPGSTATION" -> epgStationLiveRepository
+                else -> konomiRepository
+            }
+            provider.getChannelLogoUrl(channelId).also {
+                ChannelLogoUrlCache.put(backend, channelId, it)
+            }
         } catch (e: Exception) {
             Log.w("DtvProviderProxy", "getChannelLogoUrl failed or not implemented. Skipping.")
             ""

--- a/app/src/main/java/com/beeregg2001/komorebi/data/repository/EpgRepository.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/repository/EpgRepository.kt
@@ -28,12 +28,24 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 import javax.inject.Inject
+import javax.inject.Singleton
 
 data class EpgSearchResultItem(
     val program: EpgProgram,
     val channel: EpgChannel
 )
 
+/**
+ * ★ 最適化: @Singleton を付与。
+ * このクラスは番組表データの巨大なメモリキャッシュ([memoryCache])を保持しているが、
+ * スコープ未指定だったため Hilt が注入先ごとに別インスタンスを生成していた。
+ * 実際 EpgViewModel と HomeViewModel の 2 箇所から注入されており、
+ *   - 全放送種別の番組表データがメモリ上に二重に載る（数 MB〜数十 MB 規模）
+ *   - 片方が温めたキャッシュをもう片方が使えず、Room 読み出し + GZIP 展開 + Gson パースを
+ *     それぞれ独立にやり直す
+ * という無駄が発生していた。シングルトン化でこの二重化を解消する。
+ */
+@Singleton
 class EpgRepository @Inject constructor(
     @ApplicationContext private val context: Context, // ★ 追加: キャッシュディレクトリを使用するためContextを注入
     private val epgProvider: EpgProvider,

--- a/app/src/main/java/com/beeregg2001/komorebi/data/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/repository/SettingsRepository.kt
@@ -35,6 +35,19 @@ class SettingsRepository @Inject constructor(
         val KONOMI_PORT = stringPreferencesKey("konomi_port")
         val MIRAKURUN_IP = stringPreferencesKey("mirakurun_ip")
         val MIRAKURUN_PORT = stringPreferencesKey("mirakurun_port")
+
+        /**
+         * ★ 追加: これらのキーが更新されたら局ロゴ URL の共有キャッシュを破棄する。
+         * バックエンド種別と各接続先(IP/ポート)が URL の決定要素になっているため。
+         */
+        val LOGO_URL_AFFECTING_KEYS = setOf(
+            BACKEND_TYPE,
+            EDCB_IP, EDCB_PORT, EDCB_HTTP_PORT,
+            EPGSTATION_IP, EPGSTATION_PORT,
+            KONOMI_IP, KONOMI_PORT,
+            MIRAKURUN_IP, MIRAKURUN_PORT
+        )
+
         val PREFERRED_STREAM_SOURCE = stringPreferencesKey("preferred_stream_source")
         val COMMENT_SPEED = stringPreferencesKey("comment_speed")
         val COMMENT_FONT_SIZE = stringPreferencesKey("comment_font_size")
@@ -211,6 +224,11 @@ class SettingsRepository @Inject constructor(
         value: String
     ) {
         context.dataStore.edit { settings -> settings[key] = value }
+        // ★ 最適化に伴う整合性維持: 接続先が変わると局ロゴ URL も変わるため、
+        //   共有 URL キャッシュを破棄して古い URL を返さないようにする。
+        if (key in LOGO_URL_AFFECTING_KEYS) {
+            ChannelLogoUrlCache.clear()
+        }
     }
 
     suspend fun saveBoolean(

--- a/app/src/main/java/com/beeregg2001/komorebi/data/repository/edcb/EdcbRecordRepository.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/data/repository/edcb/EdcbRecordRepository.kt
@@ -140,15 +140,18 @@ class EdcbRecordRepository @Inject constructor(
             }
         }
 
+    // ★ 修正: 以前はここで edcbRecordPlayMethod(録画ファイルの再生方式)を見て、
+    // "DIRECT" なら即座に「オリジナル (Direct)」の1件だけを返していた。
+    // このメソッドは RecordProvider のメソッドだが、LivePlayerViewModel も
+    // (EDCBのライブ視聴用に専用の取得口が無いため)そのまま呼び出しており、
+    // 「録画ファイルの再生方式」という録画専用の設定が、本来無関係なはずの
+    // ライブ視聴側のトランスコード画質選択まで巻き込んで「オリジナル (Direct)」
+    // 一択に縮退させてしまっていた(録画をAPI経由に変更すると直る、という
+    // 症状と一致)。録画をDIRECT運用する場合の分岐は呼び出し元
+    // (VideoPlayerViewModel.fetchAvailableQualities)側で既に行っているため、
+    // ここでは常にresolver.luaの動的な画質リストを返す。
     override suspend fun getStreamQualities(): List<StreamQuality> = withContext(Dispatchers.IO) {
         try {
-            val playMethod = settingsRepository.edcbRecordPlayMethod.first()
-            if (playMethod == "DIRECT") {
-                return@withContext listOf(
-                    StreamQuality(label = "オリジナル (Direct)", value = "direct", isRawTs = true)
-                )
-            }
-
             val baseUrl = getHttpBaseUrl()
             val settings = fetchResolverSettings(baseUrl)
             return@withContext settings?.options ?: emptyList()

--- a/app/src/main/java/com/beeregg2001/komorebi/di/NetworkModule.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/di/NetworkModule.kt
@@ -1,5 +1,6 @@
 package com.beeregg2001.komorebi.di
 
+import com.beeregg2001.komorebi.BuildConfig
 import com.beeregg2001.komorebi.data.SettingsRepository
 import com.beeregg2001.komorebi.data.api.KonomiApi
 import com.beeregg2001.komorebi.data.model.StreamSource
@@ -71,8 +72,22 @@ object NetworkModule {
             init(null, trustAllCerts, SecureRandom())
         }
 
+        // ★ 重要 (起動速度): 以前はここが Level.BODY だった。
+        // BODY はレスポンス本文を丸ごとメモリへ読み切ってから文字列化し logcat へ流すため、
+        // 数MB規模の JSON を返す EPG API では
+        //   ・本文全体の二重デコード (ログ用 + Gson 用)
+        //   ・巨大文字列の生成による GC 多発
+        //   ・logd への大量書き込み
+        // が発生する。起動直後は EPG / チャンネル一覧の取得が集中するため、
+        // これが「起動直後だけ操作が絶望的に重い」最大の要因になっていた。
+        // Cloudflare Access の診断はヘッダーが見えれば足りるので、
+        // デバッグビルドでも HEADERS までに留め、リリースでは完全に無効化する。
         val logging = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BODY
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.HEADERS
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
             // Cloudflare Access のシークレットは logcat に平文で残さない
             redactHeader(SettingsRepository.CF_ACCESS_CLIENT_SECRET_HEADER)
         }
@@ -145,7 +160,11 @@ object NetworkModule {
         cloudflareAccessInterceptor: CloudflareAccessInterceptor
     ): OkHttpClient {
         val logging = HttpLoggingInterceptor().apply {
-            level = HttpLoggingInterceptor.Level.BASIC
+            level = if (BuildConfig.DEBUG) {
+                HttpLoggingInterceptor.Level.BASIC
+            } else {
+                HttpLoggingInterceptor.Level.NONE
+            }
             redactHeader(SettingsRepository.CF_ACCESS_CLIENT_SECRET_HEADER)
         }
         return trustAllClient(OkHttpClient.Builder())

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/components/ChannelLogo.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/components/ChannelLogo.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.Channel
 
 @Composable
@@ -27,26 +28,45 @@ fun ChannelLogo(
     backgroundColor: Color = Color.Transparent
 ) {
     val isKonomiMode = isKonomiTvMode(mirakurunIp)
-    // ★ 修正: 非同期でロゴURLを取得する
-    var logoUrl by remember(channel.id) { mutableStateOf<String>("") }
+
+    // ★ 最適化: 解決済みの URL があれば同期的に初期値として使う。
+    //   従来は必ず "" から始めて LaunchedEffect で解決していたため、
+    //   リスト内でこの Composable が作り直されるたびに
+    //   (1) コルーチンの往復が発生し
+    //   (2) "" -> URL の 2 段階再コンポーズでロゴが一瞬消えてから出る「チラつき」
+    //   が起きていた。共有キャッシュにヒットすれば最初のフレームから正しい URL で描画される。
+    var logoUrl by remember(channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(channel.id) ?: "")
+    }
     LaunchedEffect(channel.id) {
-        logoUrl = getLogoUrl(channel.id)
+        // 同期取得できた場合は再解決不要
+        if (logoUrl.isEmpty()) {
+            logoUrl = getLogoUrl(channel.id)
+        }
     }
 
     // KonomiTVモード（元画像が正方形）の場合はCropして16:9枠に合わせる
     // Mirakurunモード（元画像が透過PNG等）の場合はFitで全体を収める
     val contentScale = if (isKonomiMode) ContentScale.Crop else ContentScale.Fit
 
+    val context = LocalContext.current
+    // ★ 最適化: ImageRequest は URL が変わったときだけ組み立て直す。
+    //   毎回の再コンポーズで Builder を回すと AsyncImage 側が「別リクエスト」とみなし、
+    //   キャッシュヒットでも余計な状態遷移が走る。
+    val request = remember(context, logoUrl) {
+        ImageRequest.Builder(context)
+            .data(logoUrl)
+            // ★最適化: TVデバイスで激しい処理落ちを引き起こすcrossfadeを無効化
+            .crossfade(false)
+            .build()
+    }
+
     Box(
         modifier = modifier.background(backgroundColor),
         contentAlignment = Alignment.Center
     ) {
         AsyncImage(
-            model = ImageRequest.Builder(LocalContext.current)
-                .data(logoUrl)
-                // ★最適化: TVデバイスで激しい処理落ちを引き起こすcrossfadeを無効化
-                .crossfade(false)
-                .build(),
+            model = request,
             contentDescription = null,
             modifier = Modifier.fillMaxSize(),
             contentScale = contentScale

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/components/KeywordConditionCard.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/components/KeywordConditionCard.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.*
 import coil.compose.AsyncImage
 import com.beeregg2001.komorebi.common.UrlBuilder
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.Channel
 import com.beeregg2001.komorebi.data.model.ReservationCondition
 import com.beeregg2001.komorebi.data.model.ReserveItem
@@ -96,15 +97,20 @@ fun KeywordConditionCard(
     }
 
     // ★修正: EDCB/KonomiTV両対応の非同期ロゴ取得
-    var logoUrl by remember(displayId) { mutableStateOf("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得（チラつき・再解決の防止）
+    var logoUrl by remember(displayId) {
+        mutableStateOf(ChannelLogoUrlCache.peek(displayId) ?: "")
+    }
     LaunchedEffect(displayId) {
-        if (displayId.isNotEmpty()) {
+        if (displayId.isEmpty()) {
+            logoUrl = ""
+        } else if (logoUrl.isEmpty()) {
+            // キャッシュヒット時は再解決しない（ヒット時にここへ来ると URL を空へ戻してしまうため
+            // 元の if/else 構造のままガードを足さないこと）
             val fetchedUrl = getLogoUrl(displayId)
             logoUrl = fetchedUrl.ifEmpty {
                 UrlBuilder.getKonomiTvLogoUrl(konomiIp, konomiPort, displayId)
             }
-        } else {
-            logoUrl = ""
         }
     }
 

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/components/ReserveCard.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/components/ReserveCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.*
 import coil.compose.AsyncImage
 import com.beeregg2001.komorebi.common.UrlBuilder
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.ReserveItem
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
 import java.time.OffsetDateTime
@@ -119,9 +120,13 @@ fun ReserveCard(
 
     // ★修正: EDCBとKonomiTVの両方に対応した非同期ロゴ取得
     val displayId = item.channel.displayChannelId ?: item.channel.id
-    var logoUrl by remember(item.channel.id) { mutableStateOf("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得（チラつき・再解決の防止）
+    var logoUrl by remember(item.channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(displayId) ?: "")
+    }
 
     LaunchedEffect(item.channel.id) {
+        if (logoUrl.isNotEmpty()) return@LaunchedEffect
         val fetchedUrl = getLogoUrl(displayId)
         logoUrl = fetchedUrl.ifEmpty {
             // 取得できなかった場合はKonomiTVのURLビルダーにフォールバック

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/epg/ModernEpgCanvasEngine.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/epg/ModernEpgCanvasEngine.kt
@@ -245,13 +245,26 @@ fun ModernEpgCanvasEngine_Smooth(
             stiffness = 2500f
         )
 
-        val scrollX by animateFloatAsState(epgState.targetScrollX, scrollSpec, label = "sX")
-        val scrollY by animateFloatAsState(epgState.targetScrollY, scrollSpec, label = "sY")
-        val animX by animateFloatAsState(epgState.targetAnimX, scrollSpec, label = "aX")
-        val animY by animateFloatAsState(epgState.targetAnimY, scrollSpec, label = "aY")
-        val animH by animateFloatAsState(epgState.targetAnimH, scrollSpec, label = "aH")
-
-        val animValues = EpgAnimValues(scrollX, scrollY, animX, animY, animH)
+        // ★ 最適化(最重要): アニメーション値を「コンポーズ段階では読まない」。
+        //
+        // 従来は `val scrollX by animateFloatAsState(...)` のように委譲プロパティで
+        // 値を読んでいたため、スクロール／フォーカス移動のアニメーション中は
+        // 毎フレーム BoxWithConstraints 配下の巨大な Composable ツリー全体が
+        // 再コンポーズされていた。1 フレームごとに
+        //   - filteredLogoPainters の map と rememberAsyncImagePainter の再実行
+        //   - EpgHeaderSection を含む全子要素の再評価
+        //   - 全 remember キーの再比較と onKeyEvent ラムダの再生成
+        // が走るため、非力な Android TV では番組表のスクロールが露骨に重くなる。
+        //
+        // State オブジェクトのまま保持し、`.value` の読み取りを onDrawBehind の中
+        // （＝描画フェーズ）まで遅延させることで、アニメーション中の無効化を
+        // 「描画のみ」に限定できる。アニメーション自体は内部のコルーチンで進むため、
+        // コンポーズ段階で読まなくても正しく動作する。
+        val scrollXState = animateFloatAsState(epgState.targetScrollX, scrollSpec, label = "sX")
+        val scrollYState = animateFloatAsState(epgState.targetScrollY, scrollSpec, label = "sY")
+        val animXState = animateFloatAsState(epgState.targetAnimX, scrollSpec, label = "aX")
+        val animYState = animateFloatAsState(epgState.targetAnimY, scrollSpec, label = "aY")
+        val animHState = animateFloatAsState(epgState.targetAnimH, scrollSpec, label = "aH")
 
         Column(modifier = Modifier.fillMaxSize()) {
             AnimatedVisibility(
@@ -414,17 +427,27 @@ fun ModernEpgCanvasEngine_Smooth(
                             .fillMaxSize()
                             .drawWithCache {
                                 onDrawBehind {
+                                    // ★ アニメーション値はここ（描画フェーズ）で初めて読む。
+                                    //   これにより値の変化は再コンポーズではなく再描画のみを誘発する。
                                     drawer.draw(
                                         drawScope = this,
                                         state = epgState,
-                                        animValues = animValues,
+                                        animValues = EpgAnimValues(
+                                            scrollXState.value,
+                                            scrollYState.value,
+                                            animXState.value,
+                                            animYState.value,
+                                            animHState.value
+                                        ),
                                         logoPainters = filteredLogoPainters,
                                         isGridFocused = isContentFocused || epgState.hasData,
                                         reserveMap = reserveMap,
                                         clockPainter = clockPainter,
                                         timeFormat = timeFormat
                                     )
-                                    hasRenderedFirstFrame = true
+                                    // 初回フレーム到達フラグ。毎フレーム書き込むと
+                                    // 描画フェーズからの state 書き込みが繰り返されるためガードする。
+                                    if (!hasRenderedFirstFrame) hasRenderedFirstFrame = true
                                 }
                             })
                 }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/epg/engine/EpgDrawer.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/epg/engine/EpgDrawer.kt
@@ -42,6 +42,54 @@ class EpgDrawer(
     private val config: EpgConfig,
     private val textMeasurer: TextMeasurer
 ) {
+    // ★ 最適化: 毎フレーム生成されていたオブジェクトをインスタンス field へ退避する。
+    //   dashPathEffect は予約枠のある番組ごと・毎フレーム生成されていた。
+    private val reserveDashEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 5f), 0f)
+
+    // ★ 最適化: フォーカス中番組の終了時刻の 1 件メモ。
+    //   従来はフォーカス枠の描画で毎フレーム OffsetDateTime.parse() を呼んでおり、
+    //   フォーカス移動アニメーション中に最も重い処理になっていた。
+    //   描画はメインスレッド単独なので単純な 1 件キャッシュで十分。
+    private var focusEndTimeKey: String? = null
+    private var focusEndTimeMs: Long = 0L
+
+    // ★ 最適化: baseTime / limitTime のエポックミリ秒メモ。
+    //   現在時刻線の判定で毎フレーム OffsetDateTime.now() と Duration.between を
+    //   呼んでいたのを、ミリ秒同士の比較・減算に置き換えるため。
+    private var cachedBaseTime: OffsetDateTime? = null
+    private var cachedBaseTimeMs: Long = 0L
+    private var cachedLimitTime: OffsetDateTime? = null
+    private var cachedLimitTimeMs: Long = 0L
+
+    private fun baseTimeMs(baseTime: OffsetDateTime): Long {
+        if (cachedBaseTime != baseTime) {
+            cachedBaseTime = baseTime
+            cachedBaseTimeMs = baseTime.toInstant().toEpochMilli()
+        }
+        return cachedBaseTimeMs
+    }
+
+    private fun limitTimeMs(limitTime: OffsetDateTime): Long {
+        if (cachedLimitTime != limitTime) {
+            cachedLimitTime = limitTime
+            cachedLimitTimeMs = limitTime.toInstant().toEpochMilli()
+        }
+        return cachedLimitTimeMs
+    }
+
+    private fun focusProgramEndMs(endTime: String?): Long {
+        val key = endTime ?: return 0L
+        if (focusEndTimeKey != key) {
+            focusEndTimeKey = key
+            focusEndTimeMs = try {
+                OffsetDateTime.parse(key).toInstant().toEpochMilli()
+            } catch (e: Exception) {
+                0L
+            }
+        }
+        return focusEndTimeMs
+    }
+
     @RequiresApi(Build.VERSION_CODES.O)
     fun draw(
         drawScope: DrawScope,
@@ -56,7 +104,7 @@ class EpgDrawer(
         with(drawScope) {
             val curX = animValues.scrollX
             val curY = animValues.scrollY
-            val nowTime = OffsetDateTime.now()
+            // ★ 最適化: 毎フレームの OffsetDateTime.now() を廃止し、ミリ秒だけで判定する
             val nowMs = System.currentTimeMillis()
 
             val isDarkTheme = config.colorBg.luminance() < 0.5f
@@ -242,14 +290,12 @@ class EpgDrawer(
                                 if (reserve != null) {
                                     val borderColor =
                                         if (isPartial) config.colorReserveBorderPartial else config.colorReserveBorder
-                                    val dashEffect =
-                                        PathEffect.dashPathEffect(floatArrayOf(10f, 5f), 0f)
                                     drawRoundRect(
                                         color = borderColor,
                                         topLeft = Offset(x + 2f, py + 2f),
                                         size = Size(config.cwPx - 4f, (ph - 4f).coerceAtLeast(0f)),
                                         cornerRadius = CornerRadius(4f),
-                                        style = Stroke(width = 5f, pathEffect = dashEffect)
+                                        style = Stroke(width = 5f, pathEffect = reserveDashEffect)
                                     )
                                 }
                             }
@@ -261,8 +307,10 @@ class EpgDrawer(
             // ==========================================
             // 2. 現在時刻線 (Current Time Line)
             // ==========================================
-            if (nowTime.isAfter(state.baseTime) && nowTime.isBefore(state.limitTime)) {
-                val nowOff = Duration.between(state.baseTime, nowTime).toMinutes().toFloat()
+            val baseMs = baseTimeMs(state.baseTime)
+            val limitMs = limitTimeMs(state.limitTime)
+            if (nowMs > baseMs && nowMs < limitMs) {
+                val nowOff = ((nowMs - baseMs) / 60_000L).toFloat()
                 val nowY = config.hhAreaPx + curY + (nowOff / 60f * config.hhPx)
                 if (nowY > config.hhAreaPx && nowY < size.height) {
                     drawLine(
@@ -303,11 +351,8 @@ class EpgDrawer(
                             ignoreCase = true
                         ))
 
-                    val endTimeMs = try {
-                        OffsetDateTime.parse(p.end_time).toInstant().toEpochMilli()
-                    } catch (e: Exception) {
-                        0L
-                    }
+                    // ★ 最適化: 毎フレームの OffsetDateTime.parse を 1 件メモに置換
+                    val endTimeMs = focusProgramEndMs(p.end_time)
                     val isPast = endTimeMs > 0 && endTimeMs < nowMs
                     val isEmpty = p.title == "（番組情報なし）"
 
@@ -449,13 +494,12 @@ class EpgDrawer(
                     if (reserve != null) {
                         val borderColor =
                             if (isPartial) config.colorReserveBorderPartial else config.colorReserveBorder
-                        val dashEffect = PathEffect.dashPathEffect(floatArrayOf(10f, 5f), 0f)
                         drawRoundRect(
                             color = borderColor,
                             topLeft = Offset(fx + 2f, fy + 2f),
                             size = Size(config.cwPx - 4f, (fh - 4f).coerceAtLeast(0f)),
                             cornerRadius = CornerRadius(4f),
-                            style = Stroke(width = 5f, pathEffect = dashEffect)
+                            style = Stroke(width = 5f, pathEffect = reserveDashEffect)
                         )
                     }
 
@@ -490,13 +534,20 @@ class EpgDrawer(
                     drawRect(bgColor, Offset(0f, fy), Size(config.twPx, config.hhPx))
 
                     // ★ 修正: timeFormat の設定に応じて描画を出し分ける
+                    // ★ 最適化: 時刻ラベルの計測結果をキャッシュする。
+                    //   従来は表示中の時間帯ぶん(6〜10 行)を毎フレーム measure し直しており、
+                    //   TextMeasurer 内蔵のキャッシュ(既定 8 件)も番組タイトル計測と奪い合って
+                    //   ほとんど効いていなかった。
                     if (timeFormat == "12H") {
                         // 12時間表記 (AM/PM 付き)
                         val displayHour = if (hour == 0) 12 else if (hour > 12) hour - 12 else hour
-                        val amPmLayout =
-                            textMeasurer.measure(if (hour < 12) "AM" else "PM", config.styleAmPm)
-                        val hourLayout =
+                        val amPmText = if (hour < 12) "AM" else "PM"
+                        val amPmLayout = state.textLayoutCache.getOrPut("##ampm:$amPmText") {
+                            textMeasurer.measure(amPmText, config.styleAmPm)
+                        }
+                        val hourLayout = state.textLayoutCache.getOrPut("##hour:$displayHour") {
                             textMeasurer.measure(displayHour.toString(), config.styleTime)
+                        }
 
                         val startY =
                             fy + (config.hhPx - (amPmLayout.size.height + hourLayout.size.height + 2f)) / 2
@@ -513,7 +564,9 @@ class EpgDrawer(
                         )
                     } else {
                         // 24時間表記 (AM/PM なしで数字だけを中央に大きく表示)
-                        val hourLayout = textMeasurer.measure(hour.toString(), config.styleTime)
+                        val hourLayout = state.textLayoutCache.getOrPut("##hour:$hour") {
+                            textMeasurer.measure(hour.toString(), config.styleTime)
+                        }
                         val startY = fy + (config.hhPx - hourLayout.size.height) / 2
                         drawText(
                             hourLayout,
@@ -545,10 +598,15 @@ class EpgDrawer(
                         val logoW = 30.sp.toPx()
                         val logoH = 18.sp.toPx()
 
-                        val numLayout = textMeasurer.measure(
-                            wrapper.channel.channel_number ?: "---",
-                            config.styleChNum
-                        )
+                        // ★ 最適化: チャンネル番号／局名の計測結果をキャッシュ。
+                        //   従来は表示中の列(7〜12 列)ぶんを毎フレーム 2 回ずつ measure しており、
+                        //   横スクロール中は 1 フレームあたり 20 回以上のテキスト計測が
+                        //   メインスレッドで走っていた。内容は列ごとに固定なのでキャッシュできる。
+                        val chNumText = wrapper.channel.channel_number ?: "---"
+                        val numLayout =
+                            state.textLayoutCache.getOrPut("##chnum:${wrapper.channel.id}") {
+                                textMeasurer.measure(chNumText, config.styleChNum)
+                            }
                         val startX = x + (config.cwPx - (logoW + 6f + numLayout.size.width)) / 2
 
                         if (c < logoPainters.size) {
@@ -585,12 +643,15 @@ class EpgDrawer(
                                 6f + (logoH - numLayout.size.height) / 2
                             )
                         )
-                        val nameLayout = textMeasurer.measure(
-                            wrapper.channel.name,
-                            config.styleChName,
-                            overflow = TextOverflow.Ellipsis,
-                            constraints = Constraints(maxWidth = (config.cwPx - 16f).toInt())
-                        )
+                        val nameLayout =
+                            state.textLayoutCache.getOrPut("##chname:${wrapper.channel.id}") {
+                                textMeasurer.measure(
+                                    wrapper.channel.name,
+                                    config.styleChName,
+                                    overflow = TextOverflow.Ellipsis,
+                                    constraints = Constraints(maxWidth = (config.cwPx - 16f).toInt())
+                                )
+                            }
                         drawText(
                             nameLayout,
                             topLeft = Offset(
@@ -622,29 +683,34 @@ class EpgDrawer(
                 7 -> Color(0xFFFF5252); 6 -> Color(0xFF448AFF); else -> config.colorTextPrimary
             }
 
-            val dateLayout = textMeasurer.measure(
-                text = AnnotatedString(
-                    text = "$dateStr\n$dayStr",
-                    spanStyles = listOf(
-                        AnnotatedString.Range(
-                            SpanStyle(
-                                color = config.colorTextPrimary,
-                                fontSize = 11.sp
-                            ), 0, dateStr.length
-                        ),
-                        AnnotatedString.Range(
-                            SpanStyle(color = dayColor, fontSize = 11.sp),
-                            dateStr.length + 1,
-                            dateStr.length + 1 + dayStr.length
+            // ★ 最適化: 日付ラベルも計測結果をキャッシュ。
+            //   従来は AnnotatedString と SpanStyle 2 個を毎フレーム組み立てて measure しており、
+            //   スクロール中は表示内容が変わらないのに毎フレーム再計測していた。
+            val dateLayout = state.textLayoutCache.getOrPut("##date:$dateStr$dayStr") {
+                textMeasurer.measure(
+                    text = AnnotatedString(
+                        text = "$dateStr\n$dayStr",
+                        spanStyles = listOf(
+                            AnnotatedString.Range(
+                                SpanStyle(
+                                    color = config.colorTextPrimary,
+                                    fontSize = 11.sp
+                                ), 0, dateStr.length
+                            ),
+                            AnnotatedString.Range(
+                                SpanStyle(color = dayColor, fontSize = 11.sp),
+                                dateStr.length + 1,
+                                dateStr.length + 1 + dayStr.length
+                            )
                         )
-                    )
-                ),
-                style = config.styleDateLabel.copy(
-                    textAlign = TextAlign.Center,
-                    lineHeight = 14.sp
-                ),
-                constraints = Constraints(maxWidth = config.twPx.toInt())
-            )
+                    ),
+                    style = config.styleDateLabel.copy(
+                        textAlign = TextAlign.Center,
+                        lineHeight = 14.sp
+                    ),
+                    constraints = Constraints(maxWidth = config.twPx.toInt())
+                )
+            }
             drawText(
                 dateLayout,
                 topLeft = Offset(

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeContents.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeContents.kt
@@ -67,13 +67,14 @@ fun HomeContents(
     timeFormat: String,
 ) {
     val lazyListState = rememberLazyListState()
-    val recentRecordings by recordViewModel.recentRecordings.collectAsState()
     val isFirstItemRendered =
         remember { derivedStateOf { lazyListState.layoutInfo.visibleItemsInfo.isNotEmpty() } }
 
+    // 最初の項目がレイアウトされた時点で、ホーム画面はもう見えている。
+    // ここで待っても得られるものがないため、ローディング画面は即座に閉じる。
     LaunchedEffect(isFirstItemRendered.value) {
         if (isFirstItemRendered.value) {
-            delay(100); onUiReady()
+            onUiReady()
         }
     }
 
@@ -89,6 +90,25 @@ fun HomeContents(
         }
     }
 
+    // ★ 起動直後の待ち時間短縮:
+    // 上の3つの効果は「リストに項目が1つ以上表示された」か「ホームのデータが1件以上届いた」
+    // ことが条件になっている。そのため、初回起動でホームのデータがまだ空の場合は
+    // どれも発火せず、下の3秒の保険まで丸ごと待たされていた。
+    // (実機ログの「スプラッシュ終了→ホーム初回タブ準備完了」の数秒の空白がこれに該当する)
+    //
+    // 項目が0件でもリスト自体の測定が終われば画面としては表示できているので、
+    // 「LazyColumnがビューポートを測定し終えた」時点を準備完了の判定に加える。
+    // 測定前はviewportEndOffsetが0のままなので、描画前に発火することはない。
+    val isListMeasured =
+        remember { derivedStateOf { lazyListState.layoutInfo.viewportEndOffset > 0 } }
+
+    LaunchedEffect(isListMeasured.value) {
+        if (isListMeasured.value) {
+            delay(300); onUiReady()
+        }
+    }
+
+    // 上記のいずれも成立しない異常系のための最終保険。
     LaunchedEffect(Unit) { delay(3000); onUiReady() }
 
     val welcomeHeroInfo = remember {
@@ -262,6 +282,14 @@ fun HomeContents(
                 }
                 if (watchHistory.isNotEmpty()) {
                     item(key = "section_history") {
+                        // recentRecordings は Room の Flow で、初回起動時の録画同期中は
+                        // ページ書き込みのたびに何度も発火する。HomeContents の直下で
+                        // 購読していたため、同期が走っている間じゅうホーム画面全体
+                        // (LazyColumn のセクション定義ごと) がリコンポーズされ、
+                        // 「起動直後だけ操作が極端に重い」原因になっていた。
+                        // 実際に使うのはサムネイル用のこのセクションだけなので、
+                        // item のリコンポーズ範囲内で購読してリコンポーズを局所化する。
+                        val recentRecordings by recordViewModel.recentRecordings.collectAsState()
                         WatchHistorySection(
                             watchHistory = watchHistory,
                             recentRecordings = recentRecordings, // ★ 追加: サムネイル用データを渡す

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.tv.material3.*
+import com.beeregg2001.komorebi.ColdStartDiag
 import com.beeregg2001.komorebi.data.mapper.KonomiDataMapper
 import com.beeregg2001.komorebi.data.model.*
 import com.beeregg2001.komorebi.ui.epg.EpgNavigationContainer
@@ -46,6 +47,61 @@ import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 private const val TAG = "HomeLauncher"
+
+/**
+ * タブのコンテンツが「表示できる状態になった」ことを通知するヘルパー。
+ *
+ * 以前は各タブで一律 `delay(500)`〜`delay(800)` を挟んでから準備完了を通知していた。
+ * これはコンテンツが描画される前にローディング表示が消えてしまう「一瞬の空表示」を
+ * 避けるための対症療法だったが、実際のデータ取得がどれだけ速く終わっても
+ * 必ずその時間だけ待たされるため、起動直後や設定画面から戻った直後の
+ * ローディング表示が不必要に長引く原因になっていた。
+ *
+ * ここでは固定時間の代わりに、
+ *  1. そのタブが表示に必要とするデータが揃ったか（[isDataAvailable]）
+ *  2. 揃った後、実際に1フレーム描画されたか（[withFrameNanos]）
+ * の2点を条件にする。データが空のまま（録画0件・予約0件など）でも
+ * ローディング表示に固定されないよう、[fallbackTimeoutMs] の保険も併用する。
+ *
+ * この関数自体が独立したリコンポーズ範囲になるため、内部での状態購読が
+ * 巨大な HomeLauncherScreen 全体のリコンポーズを誘発しない点も重要。
+ */
+@Composable
+private fun TabReadyNotifier(
+    isDataAvailable: Boolean,
+    fallbackTimeoutMs: Long = 1000L,
+    onReady: () -> Unit
+) {
+    LaunchedEffect(isDataAvailable) {
+        if (isDataAvailable) {
+            // データ到達直後はまだレイアウト・描画が済んでいない。
+            // 次フレームまで待ってから通知することで、固定 delay に頼らずに
+            // 「中身が出る前にローディングが消える」ちらつきを防ぐ。
+            withFrameNanos { }
+            onReady()
+        }
+    }
+
+    // データが最後まで空のままでも操作可能にするための保険。
+    LaunchedEffect(Unit) {
+        delay(fallbackTimeoutMs)
+        onReady()
+    }
+}
+
+/**
+ * 録画予約タブ用。予約一覧の読み込み状態に連動させる。
+ * `isLoading` の購読をこの小さな関数の中に閉じ込め、
+ * HomeLauncherScreen 全体のリコンポーズを誘発しないようにしている。
+ */
+@Composable
+private fun ReserveTabReadyNotifier(
+    reserveViewModel: ReserveViewModel,
+    onReady: () -> Unit
+) {
+    val isReserveLoading by reserveViewModel.isLoading.collectAsState()
+    TabReadyNotifier(isDataAvailable = !isReserveLoading, onReady = onReady)
+}
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -122,6 +178,9 @@ fun HomeLauncherScreen(
     // Compose ツリーに残り続けるので、見えていない間の定期通信を明示的に止める。
     isPlayerActiveFullScreen: Boolean = false
 ) {
+    // ★ 追加(診断用): コールドブート計測用。詳細はhandleUiReady定義箇所を参照。
+    var hasLoggedFirstUiReady by remember { mutableStateOf(false) }
+
     val ui = rememberHomeLauncherState(
         initialTabIndex,
         channelViewModel,
@@ -149,10 +208,17 @@ fun HomeLauncherScreen(
 
     val safeTabIndex = ui.selectedTabIndex.coerceIn(0, (tabs.size - 1).coerceAtLeast(0))
 
+    // ★ 修正: 以前は `isFullScreen(...) && !hasActivePlayer` としていたため、
+    // ミニプレイヤー(PiP)表示中は設定画面などのオーバーレイが開いていても
+    // isFullScreenMode が false のままになっていた。
+    // その結果、設定画面が前面に出ているのに背面のホーム画面がフォーカス迷子検知を
+    // 走らせ、設定画面からフォーカスを奪い返してしまい操作不能になっていた。
+    // ミニプレイヤーの例外はプレイヤー起因の判定にだけ効かせる(isFullScreen側で処理)。
     val isFullScreenMode = ui.isFullScreen(
         selectedChannel, selectedProgram, epgSelectedProgram,
-        isSettingsOpen, isRecordListOpen, isReserveOverlayOpen
-    ) && !hasActivePlayer
+        isSettingsOpen, isRecordListOpen, isReserveOverlayOpen,
+        hasActivePlayer = hasActivePlayer
+    )
 
     // ★ 追加: PR #103でプレイヤー表示中もこのホーム画面自体が破棄されず常駐するようになった影響で、
     // プレイヤーを開く直前にフォーカスしていた項目の論理フォーカスが残留し、プレイヤーから戻った際の
@@ -290,10 +356,10 @@ fun HomeLauncherScreen(
     }
 
     LaunchedEffect(Unit) {
-        if (ui.selectedTabIndex == 0) {
-            homeViewModel.refreshHomeData()
-            channelViewModel.fetchChannels()
-        }
+        // ホームタブのデータ取得 (refreshHomeData / チャンネル一覧) は、この直上の
+        // LaunchedEffect(activeRenderIndex, isPlayerActiveFullScreen) が初回コンポーズ時に
+        // 必ず実行している。ここで重ねて呼ぶと、起動直後の一番重いタイミングで
+        // 同じ通信・同じ EPG 集計が二重に走ることになるため呼ばない。
         if (!isReturningFromPlayer && !isFullScreenMode) {
             delay(300)
             ticketManager.issue(HomeFocusTicket.TAB_BAR)
@@ -478,12 +544,25 @@ fun HomeLauncherScreen(
         return true
     }
 
-    // 設定ボタンへ移る際は、直前のタブ移動で仕込まれた遅延フォーカス要求を破棄する。
-    // 残しておくと、設定ボタンへ移った直後にタブへフォーカスを引き戻してしまう。
+    // 設定ボタン(または再生中ボタン)へ移る際は、直前のタブ移動で仕込まれた
+    // 遅延フォーカス要求を破棄する。残しておくと、移った直後にタブへフォーカスを
+    // 引き戻してしまう。
+    //
+    // ★ 修正: このメソッドは「最後のタブで右キーを押した」際の着地先を決める目的で
+    // 3箇所(このComposable内のonKeyEvent/onPreviewKeyEventハンドラ)から呼ばれている。
+    // これらはComposeの標準的なフォーカス探索(focusProperties { right = ... })より先に
+    // キーイベントを消費して自前でフォーカス遷移させているため、focusProperties側だけを
+    // hasActivePlayer対応させても実際には効かなかった。
+    // 再生中(PiPから復帰可能な状態)の場合は、設定ボタンではなく「再生中」ボタンへ
+    // 着地させる(再生中ボタン自体のfocusProperties.rightで設定ボタンへは行ける)。
     fun focusSettingsButton(tag: String) {
         pendingTabFocusJob?.cancel()
         ticketManager.cancelForUserNavigation()
-        ui.settingsFocusRequester.safeRequestFocus(tag)
+        if (hasActivePlayer) {
+            returnPlayerFocusRequester.safeRequestFocus(tag)
+        } else {
+            ui.settingsFocusRequester.safeRequestFocus(tag)
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {
@@ -691,6 +770,12 @@ fun HomeLauncherScreen(
                                             if (index < tabs.lastIndex) {
                                                 ui.tabFocusRequesters.getOrNull(index + 1)
                                                     ?: FocusRequester.Default
+                                            } else if (hasActivePlayer) {
+                                                // ★ 修正: 再生中(PiPから復帰可能な状態)は、最後のタブから
+                                                // 右へ進むと「再生中」ボタンに止まるべきだが、常に設定ボタンを
+                                                // 指していたため、設定ボタンを一度通過してから左キーで
+                                                // 戻らないと「再生中」ボタンを選択できない不具合があった。
+                                                returnPlayerFocusRequester
                                             } else {
                                                 ui.settingsFocusRequester
                                             }
@@ -783,6 +868,12 @@ fun HomeLauncherScreen(
             ) {
                 val currentTabLabel = tabs.getOrNull(activeRenderIndex) ?: "ホーム"
                     val handleUiReady = {
+                        // ★ 追加(診断用): コールドブートで最初のタブの中身が実際に描画され、
+                        // 操作可能になった瞬間を計測する(以降のタブ切替では再発火させない)。
+                        if (!hasLoggedFirstUiReady) {
+                            hasLoggedFirstUiReady = true
+                            ColdStartDiag.mark("HomeLauncherScreen first tab content ready")
+                        }
                         onUiReady()
                         ui.isCurrentTabContentReady = true
                     }
@@ -868,7 +959,13 @@ fun HomeLauncherScreen(
                                 aiFocusReturnTick = if (currentTabLabel == "ライブ") aiFocusReturnTick else 0,
                                 onAiReturnConsumed = onAiReturnConsumed
                             )
-                            LaunchedEffect(Unit) { delay(500); handleUiReady() }
+                            // ライブタブが表示に必要とするチャンネル一覧・グループ化データは
+                            // 呼び出し元で取得済みのものが groupedChannels として渡ってくる。
+                            // そのため取得完了を待つ必要はなく、揃っていれば次フレームで準備完了。
+                            TabReadyNotifier(
+                                isDataAvailable = groupedChannels.isNotEmpty(),
+                                onReady = handleUiReady
+                            )
                         }
 
                         "ビデオ" -> {
@@ -893,7 +990,16 @@ fun HomeLauncherScreen(
                                 aiFocusReturnTick = if (currentTabLabel == "ビデオ") aiFocusReturnTick else 0,
                                 onAiReturnConsumed = onAiReturnConsumed
                             )
-                            LaunchedEffect(Unit) { delay(500); handleUiReady() }
+                            // 録画一覧は Room の Flow から供給され、ローカル DB からの
+                            // 読み出しなので待ち合わせが必要なほど遅くはない。
+                            // ここで recentRecordings を購読すると
+                            // 初回同期中の大量の Flow 発火で HomeLauncherScreen 全体が
+                            // 作り直されてしまう（HomeLauncherState のコメント参照）ため、
+                            // 購読はせず次フレームで準備完了とする。
+                            TabReadyNotifier(
+                                isDataAvailable = true,
+                                onReady = handleUiReady
+                            )
                         }
 
                         "番組表" -> {
@@ -924,7 +1030,16 @@ fun HomeLauncherScreen(
                                 onClearSearch = { epgViewModel.clearSearch() },
                                 timeFormat = timeFormat
                             )
-                            LaunchedEffect(Unit) { delay(800); handleUiReady() }
+                            // 番組表は Canvas でグリッド全体を描画するため他タブより重い。
+                            // 他タブが 500ms なのに対しここだけ 800ms だったのはその描画コストを
+                            // 固定時間で吸収しようとしたためだが、EPG の読み込み完了状態
+                            // (EpgUiState) を直接見れば実態に即した待ち合わせになる。
+                            // グリッド描画が重い分、保険のタイムアウトだけ長めに取る。
+                            TabReadyNotifier(
+                                isDataAvailable = ui.epgUiState is EpgUiState.Success,
+                                fallbackTimeoutMs = 1500L,
+                                onReady = handleUiReady
+                            )
                         }
 
                         "録画予約" -> {
@@ -948,7 +1063,11 @@ fun HomeLauncherScreen(
                                 aiFocusReturnTick = if (currentTabLabel == "録画予約") aiFocusReturnTick else 0,
                                 onAiReturnConsumed = onAiReturnConsumed
                             )
-                            LaunchedEffect(Unit) { delay(500); handleUiReady() }
+                            // 予約一覧の読み込み状態に連動させる。
+                            ReserveTabReadyNotifier(
+                                reserveViewModel = reserveViewModel,
+                                onReady = handleUiReady
+                            )
                         }
 
                         "プロ野球" -> {
@@ -966,7 +1085,10 @@ fun HomeLauncherScreen(
                                 onProgramClick = { onEpgProgramSelected(it) },
                                 topNavFocusRequester = ui.tabFocusRequesters[activeRenderIndex],
                                 contentFirstItemRequester = ui.contentFirstItemRequesters[activeRenderIndex],
-                                onUiReady = { delay(500); handleUiReady() },
+                                // 野球データ(favoriteBaseballGames)は呼び出し元で
+                                // 取得済みのものを渡しているため待ち合わせは不要。
+                                // 1フレーム描画されてから準備完了を通知する。
+                                onUiReady = { withFrameNanos { }; handleUiReady() },
                                 timeFormat = timeFormat
                             )
                         }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherState.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/HomeLauncherState.kt
@@ -175,16 +175,34 @@ class HomeLauncherState(
         }
     }
 
+    /**
+     * ホーム画面が前面の別UIに覆われていて、操作対象ではない状態かどうか。
+     *
+     * ★ 重要: ミニプレイヤー(PiP)表示中はプレイヤーが画面の一部しか占有しないため、
+     * 「プレイヤー起因のフルスクリーン判定」だけを無効化する。
+     * 設定画面・録画リスト・番組詳細などのオーバーレイは、ミニプレイヤー表示中であっても
+     * 画面全体を覆うので、必ずフルスクリーン扱いにしなければならない。
+     *
+     * 以前は呼び出し側で `isFullScreen(...) && !hasActivePlayer` としていたため、
+     * ミニプレイヤー表示中に設定画面を開くとisFullScreenModeがfalseのままになり、
+     * 背面のホーム画面がフォーカス復帰処理を走らせて設定画面からフォーカスを奪ってしまっていた。
+     */
     fun isFullScreen(
         selectedChannel: Channel?,
         selectedProgram: RecordedProgram?,
         epgSelectedProgram: EpgProgram?,
         isSettingsOpen: Boolean,
         isRecordListOpen: Boolean,
-        isReserveOverlayOpen: Boolean
+        isReserveOverlayOpen: Boolean,
+        hasActivePlayer: Boolean = false
     ): Boolean {
-        return selectedChannel != null || selectedProgram != null || epgSelectedProgram != null ||
-                isSettingsOpen || isRecordListOpen || isReserveOverlayOpen || isSeriesListOpen
+        // プレイヤー起因のフルスクリーン。ミニプレイヤー表示中は該当しない。
+        val isPlayerFullScreen =
+            !hasActivePlayer && (selectedChannel != null || selectedProgram != null)
+        // 画面全体を覆うオーバーレイ。ミニプレイヤーの有無に関わらずホーム画面は裏に隠れる。
+        val isOverlayVisible = epgSelectedProgram != null || isSettingsOpen ||
+                isRecordListOpen || isReserveOverlayOpen || isSeriesListOpen
+        return isPlayerFullScreen || isOverlayVisible
     }
 
     fun handleBackNavigation(

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/LiveContents.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/LiveContents.kt
@@ -48,6 +48,7 @@ import androidx.tv.material3.*
 import coil.compose.AsyncImage
 import com.beeregg2001.komorebi.common.safeRequestFocus
 import com.beeregg2001.komorebi.common.safeRequestFocusWithRetry
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.Channel
 import com.beeregg2001.komorebi.data.model.UiChannelState
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
@@ -331,9 +332,14 @@ fun HeroDashboard(
     val isHot = (uiState.jikkyoForce ?: 0) > 500
 
     // ★ 修正: EDCB等で取得を成功させるため displayChannelId を使用する
-    var logoUrl by remember(uiState.channel.id) { mutableStateOf("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得(チラつき・再解決の防止)
+    var logoUrl by remember(uiState.channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(uiState.channel.displayChannelId) ?: "")
+    }
     LaunchedEffect(uiState.channel.id) {
-        logoUrl = channelViewModel.getChannelLogoUrl(uiState.channel.displayChannelId)
+        if (logoUrl.isEmpty()) {
+            logoUrl = channelViewModel.getChannelLogoUrl(uiState.channel.displayChannelId)
+        }
     }
 
     val formatTime = { timeStr: String? ->
@@ -568,9 +574,14 @@ fun CompactChannelCard(
     )
 
     // ★ 修正: EDCB等で取得を成功させるため displayChannelId を使用する
-    var logoUrl by remember(uiState.channel.id) { mutableStateOf("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得(チラつき・再解決の防止)
+    var logoUrl by remember(uiState.channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(uiState.channel.displayChannelId) ?: "")
+    }
     LaunchedEffect(uiState.channel.id) {
-        logoUrl = channelViewModel.getChannelLogoUrl(uiState.channel.displayChannelId)
+        if (logoUrl.isEmpty()) {
+            logoUrl = channelViewModel.getChannelLogoUrl(uiState.channel.displayChannelId)
+        }
     }
 
     Surface(

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/home/components/HomeCards.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/home/components/HomeCards.kt
@@ -30,6 +30,7 @@ import coil.compose.AsyncImage
 import coil.request.CachePolicy
 import coil.request.ImageRequest
 import com.beeregg2001.komorebi.common.UrlBuilder
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.*
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
 import com.beeregg2001.komorebi.viewmodel.SettingsViewModel
@@ -53,9 +54,12 @@ fun LastWatchedChannelCard(
     val typeLabels =
         mapOf("GR" to "地デジ", "BS" to "BS", "CS" to "CS", "BS4K" to "BS4K", "SKY" to "スカパー")
 
-    var logoUrl by remember(channel.id) { mutableStateOf("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得（チラつき・再解決の防止）
+    var logoUrl by remember(channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(channel.id) ?: "")
+    }
     LaunchedEffect(channel.id) {
-        logoUrl = getLogoUrl(channel.id)
+        if (logoUrl.isEmpty()) logoUrl = getLogoUrl(channel.id)
     }
 
     Surface(
@@ -152,9 +156,12 @@ fun HotChannelCard(
     var isFocused by remember { mutableStateOf(false) }
     val colors = KomorebiTheme.colors
 
-    var logoUrl by remember(uiState.channel.id) { mutableStateOf("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得（チラつき・再解決の防止）
+    var logoUrl by remember(uiState.channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(uiState.channel.id) ?: "")
+    }
     LaunchedEffect(uiState.channel.id) {
-        logoUrl = getLogoUrl(uiState.channel.id)
+        if (logoUrl.isEmpty()) logoUrl = getLogoUrl(uiState.channel.id)
     }
 
     Surface(

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/ChannelListOverlay.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/ChannelListOverlay.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.sp
 import androidx.tv.material3.*
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.Channel
 import com.beeregg2001.komorebi.ui.theme.KomorebiTheme
 
@@ -246,9 +247,13 @@ fun ChannelCardItem(
     val borderWidth = if (isFocused) 3.dp else 0.dp
     val borderColor = if (isFocused) colors.accent else Color.Transparent
 
-    var logoUrl by remember(channel.id) { mutableStateOf<String>("") }
+    // ★ 最適化: 解決済み URL を同期的に初期値へ。LazyRow のスクロールで
+    //   アイテムが再生成されるたびに走っていたコルーチン往復とチラつきを解消する。
+    var logoUrl by remember(channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(channel.id) ?: "")
+    }
     LaunchedEffect(channel.id) {
-        logoUrl = getLogoUrl(channel.id)
+        if (logoUrl.isEmpty()) logoUrl = getLogoUrl(channel.id)
     }
 
     Box(

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/live/LiveDualPlayer.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/live/LiveDualPlayer.kt
@@ -42,6 +42,7 @@ import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import coil.compose.AsyncImage
 import com.beeregg2001.komorebi.common.AppStrings
+import com.beeregg2001.komorebi.data.ChannelLogoUrlCache
 import com.beeregg2001.komorebi.data.model.Channel
 import com.beeregg2001.komorebi.data.model.StreamSource
 import com.beeregg2001.komorebi.ui.subtitle.NativeCaptionCue
@@ -583,10 +584,13 @@ fun DualChannelInfoOverlay(
     shouldCropLogo: Boolean,
     modifier: Modifier = Modifier
 ) {
-    var logoUrl by remember(channel.id) { mutableStateOf<String>("") }
+    // ★ 最適化: 共有キャッシュから同期的に初期値を取得(チラつき・再解決の防止)
+    var logoUrl by remember(channel.id) {
+        mutableStateOf(ChannelLogoUrlCache.peek(channel.id) ?: "")
+    }
 
     LaunchedEffect(channel.id) {
-        logoUrl = getLogoUrl(channel.id)
+        if (logoUrl.isEmpty()) logoUrl = getLogoUrl(channel.id)
     }
 
     val displayType =

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootBackground.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootBackground.kt
@@ -67,6 +67,13 @@ fun MainRootBackground(
         !state.isMiniPlayerMode &&
             (state.selectedChannel != null || state.selectedProgram != null || state.selectedSmbItem != null)
 
+    // ★ 追加: 設定画面(MainRootDialogs側で描画)は画面全体を覆うため、表示中は背面ツリーを操作できない。
+    // 特にミニプレイヤー表示中はisFullScreenPlayerVisibleがfalseになるので、
+    // 設定画面を開いても背面のホーム画面がフォーカス可能なまま残り、
+    // 設定画面のボタンにフォーカスできない・戻るキーがホーム画面側に吸われて
+    // アプリ終了確認ダイアログが出る、という操作不能状態になっていた。
+    val isBackgroundFocusBlocked = isFullScreenPlayerVisible || state.isSettingsOpen
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -85,7 +92,7 @@ fun MainRootBackground(
             // することで、このBox配下へのフォーカス侵入をフォーカス探索・明示的なrequestFocusの両方で拒否する。
             .focusProperties {
                 canFocus = false
-                if (isFullScreenPlayerVisible) {
+                if (isBackgroundFocusBlocked) {
                     onEnter = { cancelFocusChange() }
                 }
             }

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/main/MainRootScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.media3.common.util.UnstableApi
+import com.beeregg2001.komorebi.ColdStartDiag
 import com.beeregg2001.komorebi.ui.home.LoadingScreen
 import com.beeregg2001.komorebi.ui.live.LivePlayerScreen
 import com.beeregg2001.komorebi.ui.video.player.VideoPlayerScreen
@@ -400,7 +401,7 @@ fun MainRootScreen(
         false; state.showConnectionErrorDialog = false
         state.currentTabIndex = 0
         // 設定変更を確実に反映させるため、間引きを無視して更新する。
-        channelViewModel.fetchChannels(); epgViewModel.preloadAllEpgData(); homeViewModel.refreshHomeData(force = true)
+        channelViewModel.fetchChannels(force = true); epgViewModel.preloadAllEpgData(); homeViewModel.refreshHomeData(force = true)
         recordViewModel.fetchRecentRecordings(forceRefresh = false); reserveViewModel.fetchReserves()
         state.settingsInitialCategoryIndex = 0
         state.settingsInitialFocusItemIndex = null
@@ -425,6 +426,14 @@ fun MainRootScreen(
                 null
 
             state.showDeleteConfirmDialog -> state.showDeleteConfirmDialog = false
+
+            // ★ 修正: 設定画面はプレイヤーより手前(MainRootDialogs)で画面全体を覆って描画される。
+            // プレイヤー系の分岐より後ろに置いていたため、ミニプレイヤー表示中に設定画面を開くと
+            // 戻るキーを押しても設定画面が閉じず、isMiniPlayerModeの解除→プレイヤーの終了…と
+            // 背面の状態だけが消化されてしまい、最後にはホーム画面の戻る処理まで到達して
+            // アプリ終了確認ダイアログが表示されていた。前面にあるものから閉じる順序へ修正する。
+            state.isSettingsOpen -> closeSettingsAndRefresh()
+
             state.isMiniPlayerMode -> {
                 state.isMiniPlayerMode = false; state.toastMessage = "フルスクリーンに戻りました"
             }
@@ -449,7 +458,6 @@ fun MainRootScreen(
                 state.isMiniPlayerMode = false
             }
 
-            state.isSettingsOpen -> closeSettingsAndRefresh()
             state.epgSelectedProgram != null -> state.epgSelectedProgram = null
             state.selectedReserve != null -> state.selectedReserve = null
             state.isEpgJumpMenuOpen -> state.isEpgJumpMenuOpen = false
@@ -474,28 +482,42 @@ fun MainRootScreen(
         }
     }
 
+    // 起動シーケンスの判定。
+    //
+    // 以前はここに delay(300) → delay(300)(または delay(500))が直列に積まれており、
+    // 「チャンネル一覧の取得が終わっているのに600ms何も起きない」時間が生まれていた。
+    // さらに下のLaunchedEffectはisEpgReady/isSettingsInitializedをキーに持つため、
+    // 番組表の初回読み込みが完了するたびにdelayがやり直され、待ち時間が伸びていた。
+    //
+    // isChannelLoadingはChannelViewModelの初期値がtrueで、取得完了時に一度だけ
+    // falseになる(取得の重複起動もChannelViewModel側で抑止済み)ため、
+    // この時点でチャンネル一覧・エラー状態はどちらも確定している。待つ必要はない。
     LaunchedEffect(isChannelLoading, isHomeLoading) {
         if (!isChannelLoading && !isHomeLoading) {
-            delay(300)
             if (isChannelError) {
                 state.showConnectionErrorDialog = true; state.isDataReady = false
             } else {
                 state.showConnectionErrorDialog = false; state.isDataReady = true
+                ColdStartDiag.mark("isDataReady=true (channel+home data loaded)")
             }
         }
     }
 
     LaunchedEffect(isEpgReady, state.isDataReady, isSettingsInitialized, state.currentTabIndex) {
         if (!isSettingsInitialized) {
-            delay(500); state.isSplashFinished = true
+            // 初期設定が未完了なら、セットアップ画面をできるだけ早く出す。
+            state.isSplashFinished = true
         } else if (state.currentTabIndex == tabs.indexOf("番組表")) {
             if (isEpgReady && state.isDataReady) {
-                delay(300); state.isSplashFinished = true
+                state.isSplashFinished = true
             }
         } else {
             if (state.isDataReady) {
-                delay(300); state.isSplashFinished = true
+                state.isSplashFinished = true
             }
+        }
+        if (state.isSplashFinished) {
+            ColdStartDiag.mark("isSplashFinished=true")
         }
     }
 

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/main/SeasonalDecor.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/main/SeasonalDecor.kt
@@ -50,26 +50,55 @@ fun SeasonalDecor(season: String, isDark: Boolean, modifier: Modifier = Modifier
         else -> season
     }
 
-    val infiniteTransition = rememberInfiniteTransition(label = "kyle_swim")
-    val kyleX by infiniteTransition.animateFloat(
-        initialValue = 2400f,
-        targetValue = -600f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 45000, easing = LinearEasing),
-            repeatMode = RepeatMode.Restart
-        ), label = "kyle_x"
-    )
+    // ★ 最適化(アプリ全体に効く最重要修正):
+    //
+    // この装飾はプレイヤー起動中以外の「ほぼ全画面」の背面に常時表示されている。
+    // 従来はここで rememberInfiniteTransition の値を `by` でコンポーズ段階から読んでいたため、
+    //   - 無限アニメーションが常に走り続けて毎フレーム SeasonalDecor が再コンポーズされ
+    //   - そのたびに Canvas の描画ラムダが作り直されて全画面 Canvas が毎フレーム再描画され
+    //   - 描画では Random を作り直して 25〜40 個の花びら／星をパスで描き直していた
+    // という状態だった。しかも kyleX / kyleYOffset を実際に使うのは KYLE_* の 4 系統だけで、
+    // 桜・星・紅葉・雪・木漏れ日の各季節では「毎フレーム同じ絵を描き直すだけ」の完全な無駄。
+    //
+    // 対策は 2 つ:
+    //  (1) KYLE 系のとき以外は無限アニメーション自体を生成しない。
+    //      無限アニメーションは値が読まれなくてもフレーム要求を出し続けるため、
+    //      作らないこと自体が省電力・省 CPU になる。
+    //  (2) アニメーション値の読み取りを描画ラムダの中（＝描画フェーズ）まで遅延させる。
+    //      これにより KYLE 系でも再コンポーズは発生せず、再描画のみで済む。
+    //      KYLE 以外の分岐では値を一切読まないので、描画の無効化自体が起こらなくなり、
+    //      Canvas は初回に 1 度描かれたあと静止する。
+    val isKyleSeason = actualSeason.startsWith("KYLE")
 
-    val kyleYOffset by infiniteTransition.animateFloat(
-        initialValue = -30f,
-        targetValue = 30f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis = 3000, easing = FastOutSlowInEasing),
-            repeatMode = RepeatMode.Reverse
-        ), label = "kyle_y"
-    )
+    val kyleXState: State<Float>?
+    val kyleYState: State<Float>?
+    if (isKyleSeason) {
+        val infiniteTransition = rememberInfiniteTransition(label = "kyle_swim")
+        kyleXState = infiniteTransition.animateFloat(
+            initialValue = 2400f,
+            targetValue = -600f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 45000, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart
+            ), label = "kyle_x"
+        )
+        kyleYState = infiniteTransition.animateFloat(
+            initialValue = -30f,
+            targetValue = 30f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 3000, easing = FastOutSlowInEasing),
+                repeatMode = RepeatMode.Reverse
+            ), label = "kyle_y"
+        )
+    } else {
+        kyleXState = null
+        kyleYState = null
+    }
 
     Canvas(modifier = modifierWithConstraint) {
+        // ★ ここで初めてアニメーション値を読む（描画フェーズでの遅延読み取り）
+        val kyleX = kyleXState?.value ?: 0f
+        val kyleYOffset = kyleYState?.value ?: 0f
         val random = Random(actualSeason.hashCode() + (if (isDark) 1 else 0))
 
         when (actualSeason) {

--- a/app/src/main/java/com/beeregg2001/komorebi/ui/setting/SettingScreen.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/ui/setting/SettingScreen.kt
@@ -182,6 +182,14 @@ fun SettingsScreen(
         if (initialFocusItemIndex == null || uiState.selectedCategoryIndex != initialCategoryIndex) {
             mainScrollState.scrollTo(0)
         }
+        // ★ 追加: 「再生設定」タブ(画質選択ダイアログがある)を開いたタイミングで、
+        // EDCBのトランスコード画質リストを確実に再取得する。アプリ起動1.5秒後の
+        // 自動同期が失敗すると、以後リトライされずダイアログの選択肢が
+        // 「設定値」ベースの縮退リストに固定されてしまっていたため、
+        // ユーザーが実際にこの画面を見るタイミングで取り直す。
+        if (uiState.selectedCategoryIndex == 2) {
+            viewModel.refreshStreamQualities()
+        }
     }
 
     LaunchedEffect(Unit) {
@@ -506,11 +514,14 @@ fun SettingsScreen(
                             {
                                 uiState.activeDialog = SettingDialogState.Selection(
                                     "バックエンドシステムの選択",
+                                    // ★ 修正: "Mirakurun (録画なし)" はまだ未対応のため選択肢から非表示にする。
+                                    // 既にこれを選択している既存ユーザーがいる可能性を考慮し、
+                                    // SettingsRepository側の判定・分岐(MIRAKURUN_ONLY)自体は残したまま、
+                                    // 新規に選べないようにするだけに留める。
                                     listOf(
                                         "KonomiTV" to "KONOMITV",
                                         "EDCB (EpgTimerSrv)" to "EDCB",
-                                        "EPGStation" to "EPGSTATION",
-                                        "Mirakurun (録画なし)" to "MIRAKURUN_ONLY"
+                                        "EPGStation" to "EPGSTATION"
                                     ),
                                     if (listOf(
                                             "KONOMITV",

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/ChannelViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/ChannelViewModel.kt
@@ -127,6 +127,12 @@ class ChannelViewModel @Inject constructor(
     private var pollingJob: Job? = null
     private var progressUpdateJob: Job? = null
     private var fetchJob: Job? = null
+
+    // ポーリング開始時の「データが古いので即時取得」用ジョブ。
+    // startPolling() はタブ移動のたびに呼ばれるため、ポーリングループ本体
+    // (pollingJob) と同じジョブに入れておくと、取得中でも cancel → やり直しに
+    // なってしまう。取得そのものは別ジョブに分けて途中で捨てないようにする。
+    private var initialPollFetchJob: Job? = null
     private var lastFetchedTimeMillis = 0L
 
     private var isPollingPaused = false
@@ -278,14 +284,41 @@ class ChannelViewModel @Inject constructor(
         }
     }
 
+    /**
+     * チャンネル一覧を取得する。
+     *
+     * アプリ起動直後は
+     *   1. init → startPolling() の「データが古いので即時取得」
+     *   2. MainRootScreen の起動シーケンス
+     *   3. HomeLauncherScreen の初回表示
+     * という 3 箇所から、ほぼ同時に本メソッド相当の取得が要求されていた。
+     * いずれも同じエンドポイントを叩くだけなので、同一の通信が最大 3 本並走し、
+     * 非力な Android TV では起動直後の帯域と CPU を無駄に食い潰していた。
+     *
+     * 取得中の要求は既存のジョブに合流させ、通信を 1 本にまとめる。
+     *
+     * @param force 設定変更直後など、実行中のジョブを捨ててでも取り直したい場合に true。
+     */
     @RequiresApi(Build.VERSION_CODES.O)
-    fun fetchChannels() {
+    fun fetchChannels(force: Boolean = false) {
+        // 取得中の要求は既存ジョブに任せる(_isLoadingは既に true のまま)。
+        if (!force && isFetchInFlight()) {
+            Log.d("ChannelViewModel", "fetchChannels: 取得中のため要求をスキップします")
+            return
+        }
         _isLoading.value = true
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchChannelsInternal()
         }
     }
+
+    /**
+     * fetchChannels() 由来・startPolling() 由来のどちらかで取得処理が進行中かどうか。
+     * ポーリング側の初回取得も同じ通信なので、二重取得の判定に含める。
+     */
+    private fun isFetchInFlight(): Boolean =
+        fetchJob?.isActive == true || initialPollFetchJob?.isActive == true
 
     fun fetchRecentRecordings() {
         _isRecordingLoading.value = true

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/EpgViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/EpgViewModel.kt
@@ -340,6 +340,8 @@ class EpgViewModel @OptIn(UnstableApi::class)
                 result.onSuccess { data ->
                     fullEpgData = data
                     epgMemoryCache[typeToFetch] = data
+                    // ★ 時刻解析メモが無制限に膨らまないよう、元データ更新時に破棄する
+                    if (timeParseCache.size > 100_000) timeParseCache.clear()
 
                     fullLogoUrls =
                         withContext(Dispatchers.Default) { data.map { getLogoUrl(it.channel) } }
@@ -369,22 +371,54 @@ class EpgViewModel @OptIn(UnstableApi::class)
         return if (time.hour < 4) base.minusDays(1) else base
     }
 
+    /**
+     * ★ 最適化: ISO8601 文字列 -> エポックミリ秒 の解析結果メモ。
+     *
+     * [sliceAndEmitEpgData] は日付移動のたびに fullEpgData 全件を走査し、
+     * 1 番組につき start_time / end_time を 2 回 OffsetDateTime.parse していた。
+     * 100 チャンネル × 200 番組なら 1 回の日付移動で 4 万回の parse になり、
+     * 番組表の日付切り替えが目に見えて待たされる原因になっていた。
+     *
+     * 日付移動では fullEpgData 自体は変わらないため、同じ文字列を何度も解析している。
+     * メモ化により 2 回目以降の日付移動は数値比較だけで済む。
+     */
+    private val timeParseCache = java.util.concurrent.ConcurrentHashMap<String, Long>()
+
+    private fun parseEpochMillis(text: String?): Long {
+        if (text.isNullOrEmpty()) return Long.MIN_VALUE
+        return timeParseCache.getOrPut(text) {
+            try {
+                OffsetDateTime.parse(text).toInstant().toEpochMilli()
+            } catch (e: Exception) {
+                Long.MIN_VALUE
+            }
+        }
+    }
+
+    /** ★ 追加: 連続した日付移動で古いスライス処理が走り続けないようキャンセルするためのジョブ */
+    private var sliceJob: Job? = null
+
     private fun sliceAndEmitEpgData() {
         if (fullEpgData.isEmpty()) return
-        viewModelScope.launch(Dispatchers.Default) {
+        // ★ 最適化 + 競合の修正:
+        //   従来は呼ばれるたびに新しいコルーチンを起動しっぱなしだったため、
+        //   日付を素早く連打すると同じデータに対する重いスライス処理が多重に走り、
+        //   さらに完了順が前後すると古い結果が新しい結果を上書きする可能性があった。
+        sliceJob?.cancel()
+        sliceJob = viewModelScope.launch(Dispatchers.Default) {
 
             val tvDayStart = getTvDayStart(currentTargetTime)
             val tvDayEnd = tvDayStart.plusHours(24)
+            val tvDayStartMs = tvDayStart.toInstant().toEpochMilli()
+            val tvDayEndMs = tvDayEnd.toInstant().toEpochMilli()
 
             val slicedData = fullEpgData.map { wrapper ->
                 val filteredPrograms = wrapper.programs.filter { prog ->
-                    try {
-                        val pStart = OffsetDateTime.parse(prog.start_time)
-                        val pEnd = OffsetDateTime.parse(prog.end_time)
-                        pEnd.isAfter(tvDayStart) && pStart.isBefore(tvDayEnd)
-                    } catch (e: Exception) {
-                        false
-                    }
+                    val startMs = parseEpochMillis(prog.start_time)
+                    val endMs = parseEpochMillis(prog.end_time)
+                    // 解析に失敗した番組は従来どおり除外する
+                    startMs != Long.MIN_VALUE && endMs != Long.MIN_VALUE &&
+                        endMs > tvDayStartMs && startMs < tvDayEndMs
                 }
                 wrapper.copy(programs = filteredPrograms)
             }

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/HomeViewModel.kt
@@ -71,6 +71,14 @@ class HomeViewModel @Inject constructor(
     private var homeRefreshJob: Job? = null
     private var lastHomeRefreshAt = 0L
 
+    // ジャンルピックアップ / プロ野球カードの取得ジョブ。起動直後に複数経路から
+    // 同時に呼ばれても EPG 取得を 1 本にまとめるために保持する。
+    private var genrePickupJob: Job? = null
+
+    // バックエンド疎通確認は EDCB / EPGStation ではチャンネル一覧の取得そのもの。
+    // 起動直後に init 側と refreshHomeData 側の両方から呼ばれて二重に通信していた。
+    private var healthCheckJob: Job? = null
+
     companion object {
         // ホーム更新の最小間隔。これより短い連続要求は無視する。
         private const val HOME_REFRESH_MIN_INTERVAL_MS = 60_000L
@@ -166,8 +174,26 @@ class HomeViewModel @Inject constructor(
         _sharedEpgData.value = data
     }
 
-    private fun fetchAllTypeGenrePickup() {
-        viewModelScope.launch {
+    /**
+     * ジャンルピックアップ / プロ野球カードの元データを取得する。
+     *
+     * GR / BS / CS それぞれについて 3 日分の EPG を取りに行くため、1 回でも十分に重い。
+     * 起動直後は
+     *   - init の combine(...).debounce(1500) 経由
+     *   - refreshHomeData() 経由 (ホームタブの初回表示)
+     * の 2 経路からほぼ同時に呼ばれ、同じ EPG 取得と数千件のフィルタ処理が
+     * まるごと二重に走っていた。実行中の要求は既存ジョブに合流させる。
+     *
+     * @param force 設定 (ピックアップジャンル・時間帯・ひいきの球団) が変わった場合など、
+     *              実行中のジョブを捨ててでも新しい条件で取り直したい場合に true。
+     */
+    private fun fetchAllTypeGenrePickup(force: Boolean = false) {
+        if (!force && genrePickupJob?.isActive == true) {
+            Log.d("HomeViewModel", "fetchAllTypeGenrePickup: 実行中のため要求をスキップします")
+            return
+        }
+        genrePickupJob?.cancel()
+        genrePickupJob = viewModelScope.launch {
             val genre = pickupGenreLabel.value
             val timeSetting = pickupTimeSetting.value
             val isExcludePaid = excludePaidBroadcasts.value == "ON"
@@ -328,6 +354,21 @@ class HomeViewModel @Inject constructor(
         }.sortedBy { it.first.start_time }.take(15)
     }
 
+    /**
+     * バックエンドの疎通確認。実行中の要求があればその完了を待って合流し、
+     * 同じチャンネル一覧取得を二重に走らせない。
+     */
+    private suspend fun performBackendHealthCheckOnce() {
+        healthCheckJob?.takeIf { it.isActive }?.let {
+            Log.d("Komorebi_Failsafe", "Health check already running. Joining.")
+            it.join()
+            return
+        }
+        val job = viewModelScope.launch { performBackendHealthCheck() }
+        healthCheckJob = job
+        job.join()
+    }
+
     private suspend fun performBackendHealthCheck() {
         val currentBackend = settingsRepository.backendType.first()
 
@@ -359,7 +400,8 @@ class HomeViewModel @Inject constructor(
                 .distinctUntilChanged()
                 .debounce(1500L)
                 .collectLatest {
-                    fetchAllTypeGenrePickup()
+                    // 設定変更を確実に反映させるため、実行中のジョブは捨てて取り直す。
+                    fetchAllTypeGenrePickup(force = true)
                 }
         }
 
@@ -373,7 +415,7 @@ class HomeViewModel @Inject constructor(
         // ★ 修正: バックエンドのヘルスチェックも、UIが立ち上がってから（1.5秒後）実行
         viewModelScope.launch {
             delay(1500)
-            performBackendHealthCheck()
+            performBackendHealthCheckOnce()
         }
     }
 
@@ -408,7 +450,7 @@ class HomeViewModel @Inject constructor(
         homeRefreshJob = viewModelScope.launch {
             _isLoading.value = true
             try {
-                performBackendHealthCheck()
+                performBackendHealthCheckOnce()
 
                 try {
                     val backend = settingsRepository.backendType.first()

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/LivePlayerViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/LivePlayerViewModel.kt
@@ -231,17 +231,59 @@ class LivePlayerViewModel @Inject constructor(
                             )
                         )
                     } else {
-                        val json = settingsRepository.availableStreamQualities.first()
-                        if (json.isNotBlank()) {
-                            try {
-                                val type = object : TypeToken<List<StreamQuality>>() {}.type
-                                val list = gson.fromJson<List<StreamQuality>>(json, type)
-                                if (!list.isNullOrEmpty()) _availableQualities.value = list
-                                else fetchFromApiAndSave()
-                            } catch (e: Exception) {
-                                fetchFromApiAndSave()
+                        // ★ 修正(再修正): 以前はキャッシュ済みJSONを最優先し、キャッシュが空/不正な
+                        // 場合しかresolver.luaへ動的取得しに行かなかったため、EDCBサーバー側で
+                        // トランスコード(xcode)プロファイルの設定を変更しても、Komorebi側の設定
+                        // (IP/ポート/再生方式)を変更しない限りキャッシュが更新されず、
+                        // 「トランスコードを設定しても画質が動的に取得できない」不具合があった。
+                        //
+                        // そこで一度「常にresolver.luaへ動的取得し、失敗時のみキャッシュへ
+                        // フォールバック」に変更したが、これは再生開始のたびに毎回ネットワーク
+                        // 往復を待つ形になり、resolver.luaが遅い/不安定な環境では逆に
+                        // 「画質がオリジナルしか取得できない(取得失敗のフォールバックに
+                        // 落ちてしまう)」regressionを引き起こした。1.1.0-beta6まではキャッシュ
+                        // 優先で確実に動いていたため、キャッシュがあればまずそれを即座に反映して
+                        // 表示をブロックしないようにしつつ、裏で最新値を取得して更新する
+                        // (stale-while-revalidate)方式にする。
+                        val cached = readCachedQualities()
+                        if (!cached.isNullOrEmpty()) {
+                            // キャッシュがあれば即座に表示し、再生開始をブロックしない
+                            // (beta6までの挙動)。裏で最新値を取得し、取得できれば差し替える。
+                            _availableQualities.value = cached
+                            viewModelScope.launch(Dispatchers.IO) {
+                                try {
+                                    val fetched = recordProvider.getStreamQualities()
+                                    if (fetched.isNotEmpty()) {
+                                        settingsRepository.saveString(
+                                            SettingsRepository.AVAILABLE_STREAM_QUALITIES,
+                                            gson.toJson(fetched)
+                                        )
+                                        _availableQualities.value = fetched
+                                    }
+                                    // 空の場合は取得失敗とみなし、表示済みのキャッシュを維持する。
+                                } catch (e: Exception) {
+                                    Log.e(TAG, "Background quality refresh failed. Keeping cache.", e)
+                                }
                             }
-                        } else fetchFromApiAndSave()
+                        } else {
+                            // キャッシュが無い(初回起動等)場合のみ、最低限選べる状態にするため
+                            // 動的取得の完了を待つ。
+                            try {
+                                val fetched = recordProvider.getStreamQualities()
+                                if (fetched.isNotEmpty()) {
+                                    settingsRepository.saveString(
+                                        SettingsRepository.AVAILABLE_STREAM_QUALITIES,
+                                        gson.toJson(fetched)
+                                    )
+                                    _availableQualities.value = fetched
+                                } else {
+                                    useDefaultQuality()
+                                }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Initial quality fetch failed.", e)
+                                useDefaultQuality()
+                            }
+                        }
                     }
                 } else if (source == StreamSource.KONOMITV) {
                     _availableQualities.value = StreamQuality.DEFAULT_QUALITIES
@@ -286,36 +328,28 @@ class LivePlayerViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchFromApiAndSave() {
-        try {
-            Log.i(TAG, "Cache empty. Interrupting EPG to fetch qualities from API.")
-            val fetched = recordProvider.getStreamQualities()
-            if (fetched.isNotEmpty()) {
-                settingsRepository.saveString(
-                    SettingsRepository.AVAILABLE_STREAM_QUALITIES,
-                    gson.toJson(fetched)
-                )
-                _availableQualities.value = fetched
-            } else {
-                val currentLive = settingsRepository.liveQuality.first()
-                _availableQualities.value = listOf(
-                    StreamQuality(
-                        label = "設定値 ($currentLive)",
-                        value = currentLive,
-                        isRawTs = false
-                    )
-                )
-            }
+    // EDCB(トランスコード)の画質キャッシュを読み出す。無ければ/壊れていればnullを返す。
+    private suspend fun readCachedQualities(): List<StreamQuality>? {
+        val json = settingsRepository.availableStreamQualities.first()
+        if (json.isBlank()) return null
+        return try {
+            val type = object : TypeToken<List<StreamQuality>>() {}.type
+            gson.fromJson<List<StreamQuality>>(json, type)
         } catch (e: Exception) {
-            val currentLive = settingsRepository.liveQuality.first()
-            _availableQualities.value = listOf(
-                StreamQuality(
-                    label = "設定値 ($currentLive)",
-                    value = currentLive,
-                    isRawTs = false
-                )
-            )
+            null
         }
+    }
+
+    // キャッシュも動的取得も両方失敗した場合の最終フォールバック。
+    private suspend fun useDefaultQuality() {
+        val currentLive = settingsRepository.liveQuality.first()
+        _availableQualities.value = listOf(
+            StreamQuality(
+                label = "設定値 ($currentLive)",
+                value = currentLive,
+                isRawTs = false
+            )
+        )
     }
 
     fun saveLiveQuality(qualityValue: String) {

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/RecordViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/RecordViewModel.kt
@@ -241,7 +241,17 @@ class RecordViewModel @Inject constructor(
         }
 
         viewModelScope.launch {
-            delay(2000)
+            // 録画一覧の同期はネットワーク・Room 書き込みともに重い。
+            //
+            // 初回構築が終わっていない場合はこの同期自体が起動のクリティカルパス
+            // (ローディング画面に進捗が出る) なので早めに始める。
+            // 一方、構築済みの通常起動では差分確認にすぎないため、ホーム画面が
+            // 描画されてフォーカスが落ち着くまで待ってから始める。ここで
+            // 起動直後に走らせると、Room への書き込みのたびに録画一覧の Flow が
+            // 発火し、ホーム画面の初回描画と CPU / ディスクを奪い合って
+            // 「起動直後だけ操作が極端に重い」状態を作っていた。
+            val alreadyBuilt = syncEngine.isInitialBuildCompleted()
+            delay(if (alreadyBuilt) 6000L else 1500L)
             syncEngine.launchSyncAllRecords()
         }
     }

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/SettingsViewModel.kt
@@ -411,6 +411,21 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    // ★ 追加: init内の自動同期は「アプリ起動後1.5秒経過時点で1回だけ」しか行われないため、
+    // その瞬間にEDCBのresolver.lua取得がたまたま失敗すると(サーバー起動タイミング・
+    // 一時的な通信不調等)、以後リトライされず、_dynamicQualities が空のまま固定されてしまう。
+    // 結果、設定画面の「再生設定」の画質選択ダイアログが「設定値」ベースの
+    // ダミー1〜2件だけの縮退リストになり、実質選べない状態になっていた
+    // (Komorebi側の設定変更(IP/ポート/再生方式)を行わない限り再同期のきっかけが無かった)。
+    // ユーザーが実際に設定画面(再生設定タブ)を開いたタイミングは「今まさにこのデータを
+    // 見ようとしている」という強いシグナルなので、そのタイミングで確実に取り直せるよう
+    // 公開関数として用意する。
+    fun refreshStreamQualities() {
+        viewModelScope.launch {
+            forceSyncStreamQualities()
+        }
+    }
+
     private suspend fun forceSyncStreamQualities() {
         withContext(Dispatchers.IO) {
             try {

--- a/app/src/main/java/com/beeregg2001/komorebi/viewmodel/VideoPlayerViewModel.kt
+++ b/app/src/main/java/com/beeregg2001/komorebi/viewmodel/VideoPlayerViewModel.kt
@@ -94,21 +94,58 @@ class VideoPlayerViewModel @Inject constructor(
                             )
                         )
                     } else {
-                        val json = settingsRepository.availableStreamQualities.first()
-                        if (json.isNotBlank()) {
-                            try {
-                                val type = object : TypeToken<List<StreamQuality>>() {}.type
-                                val list = gson.fromJson<List<StreamQuality>>(json, type)
-                                if (!list.isNullOrEmpty()) {
-                                    _availableQualities.value = list
-                                } else {
-                                    fetchFromApiAndSave()
+                        // ★ 修正(再修正): 以前はキャッシュ済みJSONを最優先し、キャッシュが空/不正な
+                        // 場合しかresolver.luaへ動的取得しに行かなかったため、EDCBサーバー側で
+                        // トランスコード(xcode)プロファイルの設定を変更しても、Komorebi側の設定
+                        // (IP/ポート/再生方式)を変更しない限りキャッシュが更新されず、
+                        // 「トランスコードを設定しても画質が動的に取得できない」不具合があった。
+                        //
+                        // そこで一度「常にresolver.luaへ動的取得し、失敗時のみキャッシュへ
+                        // フォールバック」に変更したが、これは再生開始のたびに毎回ネットワーク
+                        // 往復を待つ形になり、resolver.luaが遅い/不安定な環境では逆に
+                        // 「画質がオリジナルしか取得できない(取得失敗のフォールバックに
+                        // 落ちてしまう)」regressionを引き起こした。1.1.0-beta6まではキャッシュ
+                        // 優先で確実に動いていたため、キャッシュがあればまずそれを即座に反映して
+                        // 表示をブロックしないようにしつつ、裏で最新値を取得して更新する
+                        // (stale-while-revalidate)方式にする。
+                        val cached = readCachedQualities()
+                        if (!cached.isNullOrEmpty()) {
+                            // キャッシュがあれば即座に表示し、再生開始をブロックしない
+                            // (beta6までの挙動)。裏で最新値を取得し、取得できれば差し替える。
+                            _availableQualities.value = cached
+                            viewModelScope.launch(Dispatchers.IO) {
+                                try {
+                                    val fetched = recordProvider.getStreamQualities()
+                                    if (fetched.isNotEmpty()) {
+                                        settingsRepository.saveString(
+                                            SettingsRepository.AVAILABLE_STREAM_QUALITIES,
+                                            gson.toJson(fetched)
+                                        )
+                                        _availableQualities.value = fetched
+                                    }
+                                    // 空の場合は取得失敗とみなし、表示済みのキャッシュを維持する。
+                                } catch (e: Exception) {
+                                    Log.e(TAG, "Background quality refresh failed. Keeping cache.", e)
                                 }
-                            } catch (e: Exception) {
-                                fetchFromApiAndSave()
                             }
                         } else {
-                            fetchFromApiAndSave()
+                            // キャッシュが無い(初回起動等)場合のみ、最低限選べる状態にするため
+                            // 動的取得の完了を待つ。
+                            try {
+                                val fetched = recordProvider.getStreamQualities()
+                                if (fetched.isNotEmpty()) {
+                                    settingsRepository.saveString(
+                                        SettingsRepository.AVAILABLE_STREAM_QUALITIES,
+                                        gson.toJson(fetched)
+                                    )
+                                    _availableQualities.value = fetched
+                                } else {
+                                    useDefaultQuality()
+                                }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Initial quality fetch failed.", e)
+                                useDefaultQuality()
+                            }
                         }
                     }
                 } else if (backend == "KONOMITV") {
@@ -167,37 +204,28 @@ class VideoPlayerViewModel @Inject constructor(
         }
     }
 
-    private suspend fun fetchFromApiAndSave() {
-        try {
-            Log.i(TAG, "Cache empty. Fetching qualities from API.")
-            val fetched = recordProvider.getStreamQualities()
-            if (fetched.isNotEmpty()) {
-                settingsRepository.saveString(
-                    SettingsRepository.AVAILABLE_STREAM_QUALITIES,
-                    gson.toJson(fetched)
-                )
-                _availableQualities.value = fetched
-            } else {
-                val currentVideo = settingsRepository.videoQuality.first()
-                _availableQualities.value = listOf(
-                    StreamQuality(
-                        label = "設定値 ($currentVideo)",
-                        value = currentVideo,
-                        isRawTs = false
-                    )
-                )
-            }
+    // EDCB(トランスコード)の画質キャッシュを読み出す。無ければ/壊れていればnullを返す。
+    private suspend fun readCachedQualities(): List<StreamQuality>? {
+        val json = settingsRepository.availableStreamQualities.first()
+        if (json.isBlank()) return null
+        return try {
+            val type = object : TypeToken<List<StreamQuality>>() {}.type
+            gson.fromJson<List<StreamQuality>>(json, type)
         } catch (e: Exception) {
-            Log.e(TAG, "Failed to fetch from API", e)
-            val currentVideo = settingsRepository.videoQuality.first()
-            _availableQualities.value = listOf(
-                StreamQuality(
-                    label = "設定値 ($currentVideo)",
-                    value = currentVideo,
-                    isRawTs = false
-                )
-            )
+            null
         }
+    }
+
+    // キャッシュも動的取得も両方失敗した場合の最終フォールバック。
+    private suspend fun useDefaultQuality() {
+        val currentVideo = settingsRepository.videoQuality.first()
+        _availableQualities.value = listOf(
+            StreamQuality(
+                label = "設定値 ($currentVideo)",
+                value = currentVideo,
+                isRawTs = false
+            )
+        )
     }
 
     fun setPlaybackSyncThrottle(enabled: Boolean) {


### PR DESCRIPTION
## 概要
一区切りとして、これまでの調査・修正内容をまとめてマージします。

## 変更点
- アプリ全体の動作緩慢化を調査・改善(局ロゴキャッシュ、EPG描画、季節演出、起動時のログ/WorkManager/Cloudflareインターセプタ最適化)
- PiP復帰時にタブ→再生中ボタンへフォーカスが通過してしまう不具合を修正
- PiP中に設定画面を開くとフォーカスが消失し戻るキー連打でアプリ終了ダイアログが出る不具合を修正(PR#103由来)
- EDCBの録画再生方式(直接アクセス/API経由)設定がライブ視聴の画質取得にも誤って連動していた不具合を修正
- EDCBの画質取得をキャッシュ即時表示+バックグラウンド更新方式に変更し、設定画面の再生設定タブを開くたびに画質一覧を再取得するよう修正
- 未対応のMirakurun単体バックエンド選択肢を選べないよう非表示化
- タブ切り替え時の固定delay(500-800ms)を実データの準備完了検知に置き換え、初回起動時にホームのデータが空の場合の3秒フォールバックへ丸ごと落ちてしまう不具合を修正
- コールドブート計測用の軽量診断ログ(ColdStartDiag)を追加

## 動作確認
- `./gradlew assembleDebug` 成功
- 実機での動作確認済み(コールドブート/タブ切り替えについては本PRの範囲外として一旦保留、リリースビルドで比較的安定動作を確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)